### PR TITLE
Version 0.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,33 @@
 {
-  "originHash" : "ffe6b045ec4dedfbdd9fd346f3908545121f4e2a98de6873a3e2c5f2c12018e4",
+  "originHash" : "d418bda75b139f41d9bc8a5ad895310de11d1fc948408f556c57999af63fa54e",
   "pins" : [
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
+        "version" : "1.0.4"
+      }
+    },
     {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
@@ -8,6 +35,15 @@
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "999fd70c7803da89f3904d635a6815a2a7cd7585",
+        "version" : "1.10.0"
       }
     },
     {
@@ -20,12 +56,102 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "e8d6eba1fef23ae5b359c46b03f7d94be2f41fed",
+        "version" : "3.12.3"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "db6eea3692638a65e2124990155cd220c2915903",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3d8596ed08bd13520157f0355e35caed215ffbfa",
+        "version" : "1.6.3"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
-        "version" : "2.83.0"
+        "revision" : "ad6b5f17270a7008f60d35ec5378e6144a575162",
+        "version" : "2.84.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "145db1962f4f33a4ea07a32e751d5217602eea29",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "5ca52e2f076c6a24451175f575f390569381d6a1",
+        "version" : "1.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "36b48956eb6c0569215dc15a587b491d2bb36122",
+        "version" : "2.32.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "decfd235996bc163b44e10b8a24997a3d2104b90",
+        "version" : "1.25.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
+        "version" : "2.8.0"
       }
     },
     {
@@ -35,6 +161,15 @@
       "state" : {
         "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "websocket-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor/websocket-kit.git",
+      "state" : {
+        "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
+        "version" : "2.16.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "ffe6b045ec4dedfbdd9fd346f3908545121f4e2a98de6873a3e2c5f2c12018e4",
+  "pins" : [
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "34d486b01cd891297ac615e40d5999536a1e138d",
+        "version" : "2.83.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["Monarca"]),
     ],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0")
+		.package(url: "https://github.com/vapor/websocket-kit.git", from: "2.16.0"),
 	],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -24,11 +24,7 @@ let package = Package(
         .target(
             name: "Monarca",
 			dependencies: [
-				.product(name: "NIOCore", package: "swift-nio"),
-				.product(name: "NIOPosix", package: "swift-nio"),
-				.product(name: "NIOHTTP1", package: "swift-nio"),
-				.product(name: "NIOWebSocket", package: "swift-nio"),
-				.product(name: "NIOFoundationCompat", package: "swift-nio")
+				.product(name: "WebSocketKit", package: "websocket-kit")
 			]
 		),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Monarca",
 	platforms: [
 		.iOS(.v13),
-		.macOS(.v10_15)
+		.macOS(.v13)
 	],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -15,11 +15,21 @@ let package = Package(
             name: "Monarca",
             targets: ["Monarca"]),
     ],
+	dependencies: [
+		.package(url: "https://github.com/apple/swift-nio.git", from: "2.83.0")
+	],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "Monarca"
+            name: "Monarca",
+			dependencies: [
+				.product(name: "NIOCore", package: "swift-nio"),
+				.product(name: "NIOPosix", package: "swift-nio"),
+				.product(name: "NIOHTTP1", package: "swift-nio"),
+				.product(name: "NIOWebSocket", package: "swift-nio"),
+				.product(name: "NIOFoundationCompat", package: "swift-nio")
+			]
 		),
         .testTarget(
             name: "MonarcaTests",

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Monarca is licensed under the MIT License. See LICENSE for details.
 	- `applyContentFilter(by:)` Process only those messages that contains 1 or N of the given hashtags
 	- `applyHashtagFilter(by:)` Process only those messages that contains 1 or N of the given words
 - Information about**video** in a *Post* message.
+- Support for the following Commit collections
+	- `app.bsky.feed.threadgate`
+	- `app.bsky.feed.postgate`
 
 ### 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Monarca is licensed under the MIT License. See LICENSE for details.
 - Now you can filter `app.bsky.feed.post` messages by hashtag or by content with the new functions availables in the `BskyFirehoseClientBuilder` implementation
 	- `applyContentFilter(by:)` Process only those messages that contains 1 or N of the given hashtags
 	- `applyHashtagFilter(by:)` Process only those messages that contains 1 or N of the given words
+- Information about**video** in a *Post* message.
 
 ### 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Include the following line in the `dependencies` section of your *Package.swift*
 ...
 dependencies: [
 	// 🦋 Monarca
-	.package(url: "https://github.com/fitomad/monarca.git", from: "0.1.0")
+	.package(url: "https://github.com/fitomad/monarca.git", from: "0.2.0")
 ]
 ...
 ```
@@ -54,33 +54,34 @@ Monarca use a [Builder pattern](https://refactoring.guru/design-patterns/builder
 
 The builder is available through the `DefaultFirehoseClientBuilder` class. You can configure the following Jetstream connection with these builder functions.
 
-- Jetstream server - `withHost`: **Mandatory**. Select one of the four general available Jetstream servers or connect to a custon server using the `.custom(server:)` case, where `server` is a `String` that contains the URL to your server.
-- `wantedCollections` - `withCollections`: A `String` array with the collection's NSID.
+- Jetstream server - `connecto(to:)`: **Mandatory**. Select one of the four general available Jetstream servers or connect to a custon server using the `.custom(server:)` case, where `server` is a `String` that contains the URL to your server.
+- `wantedCollections` - `forCollections`: A `String` array with the collection's NSID.
 - `wantedDids` - `withDecentralizedIdentifiers`: A `String` array with the repo DIDs to filter which records you receive on your stream.
-- `compress` - `withCompression`: A boolean value to enable `zstd` compression. Default `false`
+- `compress` - `compressionEnabled`: A boolean value to enable `zstd` compression. Default `false`
 - `requireHello` - `withHelloExecution`: A boolean value to replay/live-tail until the server recevies a `SubscriberOptionsUpdatePayload` over the socket in a *Subscriber Sourced Message*. Default `false`
-- `maxMessageSizeBytes` - `withMaximumMessageSize`: Filters by message size. You can set this size using the helper enumeration `MessageSize`
-- `cursor` - `withPlayback`: A unix microseconds timestamp cursor to begin playback if you reconnect or connect to a new Jetstream server. You can set the value using the helper enumeration `Playback`
+- `maxMessageSizeBytes` - `maximumMessageSizeAllowed`: Filters by message size. You can set this size using the helper enumeration `MessageSize`
+- `cursor` - `messagesPlayback(since:)`: A unix microseconds timestamp cursor to begin playback if you reconnect or connect to a new Jetstream server. You can set the value using the helper enumeration `Playback`
 
 This connection reveices all Bluesky messages for all collection and DIDs from the `jetstream1` server located in the US east coast. No compression enabled, witho no `hello` command needed and with no message size limitation.
 
 ```swift
 let bskyFirehoseClient = try await DefaultFirehoseClientBuilder()
-	.withHost(.usaEast1)
+	.connect(to: .usaEast1)
 	.build()
 ```
 
 This example connection uses all the settings available
 
 ```swift
-let bskyFirehoseClient = try await DefaultFirehoseClientBuilder()
-	.withHost(.usaEast1)
-	.withCollections([ "app.bsky.feed.post", "app.bsky.feed.like" ])
-	.withDecentralizedIdentifiers([ "did:97531", "did:13579" ])
-	.withCompressionEnabled(true)
-	.withHelloExecution(true)
-	.withMaximumMessageSize(.kilobytes(value: 2048))
-	.withPlayback(.seconds(5))
+let firehoseClient = try DefaultFirehoseClientBuilder()
+	.connect(to: .usaEast1)
+	.forCollections([ .post, .repost, .like ])
+	.withDecentralizedIdentifiers(Constants.customIdentifierList)
+	.compressionEnabled(false)
+	.withHelloExecution(false)
+	.maximumMessageSizeAllowed(.kilobytes(value: 2048))
+	.messagesPlayback(since: .seconds(5))
+	.dedicatedThreads(count: 8)
 	.build()
 ```
 
@@ -158,8 +159,8 @@ Once you finish to develop the custom message manager component, use the `withMe
 
 ```swift
 let bskyFirehoseClient = try await DefaultFirehoseClientBuilder()
-	.withHost(.usaEast1)
-	.withMessageManager(MockMessageManager)
+	.connect(to: .usaEast1)
+	.useCustomMessageManager(MockMessageManager)
 	.build()
 ```
 
@@ -175,6 +176,15 @@ Monarca is licensed under the MIT License. See LICENSE for details.
 - [Jetstream Documentation](https://docs.bsky.app/blog/jetstream)
 
 ## Version history
+
+### 0.2.0
+
+- Migrate from the `URLSessionWebSocketTask` to the [SwiftNIO](https://github.com/apple/swift-nio) based WebSocket connection using the [WebSocketKit](https://github.com/vapor/websocket-kit) framework
+- Renaming some `BskyFirehoseClientBuilder` functions to bring a *Fluid* approach to the API. Old funcions are now marked as *deprecated* and will be removed in future versions.
+- Work to adopt Swift 6 Concurrency model is still in progress.
+- Now you can filter `app.bsky.feed.post` messages by hashtag or by content with the new functions availables in the `BskyFirehoseClientBuilder` implementation
+	- `applyContentFilter(by:)` Process only those messages that contains 1 or N of the given hashtags
+	- `applyHashtagFilter(by:)` Process only those messages that contains 1 or N of the given words
 
 ### 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Monarca is a Swift project designed to consume the BlueSky Firehose using the [J
 	- `app.bsky.graph.block`
 	- `app.bsky.feed.post`
 	- `app.bsky.graph.starterpack`
+	- `app.bsky.feed.threadgate`
+	- `app.bsky.feed.postgate`
 
 ## Requirements
 
@@ -185,7 +187,7 @@ Monarca is licensed under the MIT License. See LICENSE for details.
 - Now you can filter `app.bsky.feed.post` messages by hashtag or by content with the new functions availables in the `BskyFirehoseClientBuilder` implementation
 	- `applyContentFilter(by:)` Process only those messages that contains 1 or N of the given hashtags
 	- `applyHashtagFilter(by:)` Process only those messages that contains 1 or N of the given words
-- Information about**video** in a *Post* message.
+- Information about **video** in a *Post* message.
 - Support for the following Commit collections
 	- `app.bsky.feed.threadgate`
 	- `app.bsky.feed.postgate`

--- a/Sources/Monarca/BskyFirehoseClient.swift
+++ b/Sources/Monarca/BskyFirehoseClient.swift
@@ -6,13 +6,11 @@
 //
 
 import Foundation
-import NIOCore
-import NIOHTTP1
-import NIOPosix
-import NIOWebSocket
+import NIO
 import NIOFoundationCompat
+import WebSocketKit
 
-public typealias MessageReceivedClosure = (BskyMessage) -> Void
+public typealias MessageReceivedClosure = @Sendable (BskyMessage) -> Void
 public typealias ErrorReceivedClosure = (BskyFirehoseError) -> Void
 
 public actor BskyFirehoseClient: Sendable {
@@ -22,8 +20,7 @@ public actor BskyFirehoseClient: Sendable {
 	
 	private lazy var mapper = BskyFirehoseSettingsMapper()
 	
-	private let eventLoopGroup: MultiThreadedEventLoopGroup = .singleton
-	private var channel: Channel?
+	private let eventLoopGroup: MultiThreadedEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 2)
 	
 	private var status: BskyFirehoseClient.Status = .closed
 	
@@ -36,60 +33,33 @@ public actor BskyFirehoseClient: Sendable {
 	}
 
 	public func start() async throws {
+		guard let bskyMessageManager = await settings.messageManager else {
+			throw BskyFirehoseError.messageManagerNotAvailable
+		}
+		
 		let mapper = BskyFirehoseSettingsMapper()
 		
-		guard let bskyURL = try? await mapper.mapToURL(from: settings),
-			  let parsedURL = mapper.mapToWebSocketBootstrap(from: bskyURL)
-		else
-		{
+		guard let bskyURL = try? await mapper.mapToURL(from: settings) else {
 			throw BskyFirehoseError.invalidConnectionParameters
 		}
 		
-		let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(group: self.eventLoopGroup)
-			.connect(host: parsedURL.host, port: parsedURL.port) { channel in
-			channel.eventLoop.makeCompletedFuture {
-				let upgrader = NIOTypedWebSocketClientUpgrader<UpgradeResult>(
-					upgradePipelineHandler: { (channel, _) in
-						channel.eventLoop.makeCompletedFuture {
-							let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(
-								wrappingChannelSynchronously: channel
-							)
-							return UpgradeResult.websocket(asyncChannel)
-						}
+		WebSocket.connect(to: bskyURL, on: eventLoopGroup) { ws in
+				var incomingMessage: BskyMessage?
+				
+				ws.onText { ws, content in
+					if let incomingMessage = try? await bskyMessageManager.processMessage(string: content) {
+						await self.onMessageReceived?(incomingMessage)
 					}
-				)
+				}
 				
-				var headers = HTTPHeaders()
-				headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
-				headers.add(name: "Content-Length", value: "0")
-				
-				let requestHead = HTTPRequestHead(
-					version: .http1_1,
-					method: .GET,
-					uri: parsedURL.path.isEmpty ? "/" : parsedURL.path,
-					headers: headers
-				)
-				
-				let clientUpgradeConfiguration = NIOTypedHTTPClientUpgradeConfiguration(
-					upgradeRequestHead: requestHead,
-					upgraders: [upgrader],
-					notUpgradingCompletionHandler: { channel in
-						channel.eventLoop.makeCompletedFuture {
-							UpgradeResult.notUpgraded
-						}
+				ws.onBinary { ws, byteBuffer in
+					let data = Data(buffer: byteBuffer)
+					if let incomingMessage = try? await bskyMessageManager.processMessage(content: data) {
+						await self.onMessageReceived?(incomingMessage)
 					}
-				)
-				
-				let negotiationResultFuture = try channel.pipeline.syncOperations
-					.configureUpgradableHTTPClientPipeline(
-						configuration: .init(upgradeConfiguration: clientUpgradeConfiguration)
-					)
-				
-				return negotiationResultFuture
-			}
+				}
 		}
-		
-		try await self.handleUpgradeResult(upgradeResult)
+
 		
 		status = .connected
 	}
@@ -100,60 +70,6 @@ public actor BskyFirehoseClient: Sendable {
 		}
 		
 		status = .closed
-	}
-	
-	private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async throws {
-		guard let result = try? await upgradeResult.get() else {
-			throw BskyFirehoseError.invalidFirehoseURL
-		}
-		
-		switch result {
-			case .websocket(let websocketChannel):
-				print("Handling websocket connection")
-				try await self.handleWebsocketChannel(websocketChannel)
-				print("Done handling websocket connection")
-			case .notUpgraded:
-				// The upgrade to websocket did not succeed. We are just exiting in this case.
-				print("Upgrade declined")
-		}
-	}
-	
-	private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
-		guard let bskyMessageManager = await settings.messageManager else {
-			throw BskyFirehoseError.messageManagerNotAvailable
-		}
-
-		let pingFrame = WebSocketFrame(fin: true, opcode: .ping, data: ByteBuffer(string: "Hello!"))
-		try await channel.executeThenClose { inbound, outbound in
-			try await outbound.write(pingFrame)
-
-			for try await frame in inbound {
-				var incomingMessage: BskyMessage?
-				
-				switch frame.opcode {
-					case .pong:
-						print("Received pong: \(String(buffer: frame.data))")
-
-					case .text:
-						let content = String(buffer: frame.data)
-						incomingMessage = try await bskyMessageManager.processMessage(string: content)
-
-					case .connectionClose:
-						// Handle a received close frame. We're just going to close by returning from this method.
-						print("Received Close instruction from server")
-						return
-					case .binary, .continuation, .ping:
-						let data = Data(buffer: frame.data)
-						incomingMessage = try await bskyMessageManager.processMessage(content: data)
-					default:
-						throw BskyMessageManagerError.nonValidMessage
-				}
-				
-				if let onMessageReceived, let incomingMessage {
-					onMessageReceived(incomingMessage)
-				}
-			}
-		}
 	}
 	
 	public func onMessageReceived(_ perform: @escaping @Sendable MessageReceivedClosure) {
@@ -169,10 +85,5 @@ extension BskyFirehoseClient {
 	enum Status {
 		case connected
 		case closed
-	}
-	
-	enum UpgradeResult {
-		case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
-		case notUpgraded
 	}
 }

--- a/Sources/Monarca/BskyFirehoseClient.swift
+++ b/Sources/Monarca/BskyFirehoseClient.swift
@@ -6,6 +6,11 @@
 //
 
 import Foundation
+import NIOCore
+import NIOHTTP1
+import NIOPosix
+import NIOWebSocket
+import NIOFoundationCompat
 
 public typealias MessageReceivedClosure = (BskyMessage) -> Void
 public typealias ErrorReceivedClosure = (BskyFirehoseError) -> Void
@@ -17,7 +22,9 @@ public actor BskyFirehoseClient: Sendable {
 	
 	private lazy var mapper = BskyFirehoseSettingsMapper()
 	
-	private var websocketTask: URLSessionWebSocketTask?
+	private let eventLoopGroup: MultiThreadedEventLoopGroup = .singleton
+	private var channel: Channel?
+	
 	private var status: BskyFirehoseClient.Status = .closed
 	
 	public var isConnected: Bool {
@@ -27,72 +34,126 @@ public actor BskyFirehoseClient: Sendable {
 	init(settings:  BskyFirehoseSettings) {
 		self.settings = settings
 	}
-	
+
 	public func start() async throws {
-		guard websocketTask?.state != .running else {
-			return
+		let mapper = BskyFirehoseSettingsMapper()
+		
+		guard let bskyURL = try? await mapper.mapToURL(from: settings),
+			  let parsedURL = mapper.mapToWebSocketBootstrap(from: bskyURL)
+		else
+		{
+			throw BskyFirehoseError.invalidConnectionParameters
 		}
 		
-		try await connect()
-		self.websocketTask?.resume()
+		let upgradeResult: EventLoopFuture<UpgradeResult> = try await ClientBootstrap(group: self.eventLoopGroup)
+			.connect(host: parsedURL.host, port: parsedURL.port) { channel in
+			channel.eventLoop.makeCompletedFuture {
+				let upgrader = NIOTypedWebSocketClientUpgrader<UpgradeResult>(
+					upgradePipelineHandler: { (channel, _) in
+						channel.eventLoop.makeCompletedFuture {
+							let asyncChannel = try NIOAsyncChannel<WebSocketFrame, WebSocketFrame>(
+								wrappingChannelSynchronously: channel
+							)
+							return UpgradeResult.websocket(asyncChannel)
+						}
+					}
+				)
+				
+				var headers = HTTPHeaders()
+				headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+				headers.add(name: "Content-Length", value: "0")
+				
+				let requestHead = HTTPRequestHead(
+					version: .http1_1,
+					method: .GET,
+					uri: parsedURL.path.isEmpty ? "/" : parsedURL.path,
+					headers: headers
+				)
+				
+				let clientUpgradeConfiguration = NIOTypedHTTPClientUpgradeConfiguration(
+					upgradeRequestHead: requestHead,
+					upgraders: [upgrader],
+					notUpgradingCompletionHandler: { channel in
+						channel.eventLoop.makeCompletedFuture {
+							UpgradeResult.notUpgraded
+						}
+					}
+				)
+				
+				let negotiationResultFuture = try channel.pipeline.syncOperations
+					.configureUpgradableHTTPClientPipeline(
+						configuration: .init(upgradeConfiguration: clientUpgradeConfiguration)
+					)
+				
+				return negotiationResultFuture
+			}
+		}
+		
+		try await self.handleUpgradeResult(upgradeResult)
+		
+		status = .connected
 	}
 	
 	public func stop() {
-		guard let websocketTask else { return }
-		websocketTask.cancel(with: .normalClosure, reason: nil)
+		guard isConnected else {
+			return
+		}
+		
 		status = .closed
 	}
 	
-	public func receive() {
-		Task {
-			try await processIncomingMessage()
+	private func handleUpgradeResult(_ upgradeResult: EventLoopFuture<UpgradeResult>) async throws {
+		guard let result = try? await upgradeResult.get() else {
+			throw BskyFirehoseError.invalidFirehoseURL
+		}
+		
+		switch result {
+			case .websocket(let websocketChannel):
+				print("Handling websocket connection")
+				try await self.handleWebsocketChannel(websocketChannel)
+				print("Done handling websocket connection")
+			case .notUpgraded:
+				// The upgrade to websocket did not succeed. We are just exiting in this case.
+				print("Upgrade declined")
 		}
 	}
 	
-	private func connect() async throws(BskyFirehoseError) {
-		do {
-			let firehoseURL = try await mapper.mapToURL(from: settings)
-			websocketTask = URLSession.shared.webSocketTask(with: firehoseURL)
-			status = .connected
-		} catch FirehoseMapperError.malformedParameterURL {
-			throw .invalidFirehoseURL
-		} catch {
-			throw .invalidConnectionParameters
-		}
-	}
-	
-	private func processIncomingMessage() async throws {
+	private func handleWebsocketChannel(_ channel: NIOAsyncChannel<WebSocketFrame, WebSocketFrame>) async throws {
 		guard let bskyMessageManager = await settings.messageManager else {
 			throw BskyFirehoseError.messageManagerNotAvailable
 		}
-		
-		if let message = try await websocketTask?.receive() {
-			do {
+
+		let pingFrame = WebSocketFrame(fin: true, opcode: .ping, data: ByteBuffer(string: "Hello!"))
+		try await channel.executeThenClose { inbound, outbound in
+			try await outbound.write(pingFrame)
+
+			for try await frame in inbound {
 				var incomingMessage: BskyMessage?
 				
-				switch message {
-					case .data(let data):
-						incomingMessage = try await bskyMessageManager.processMessage(content: data)
-					case .string(let content):
+				switch frame.opcode {
+					case .pong:
+						print("Received pong: \(String(buffer: frame.data))")
+
+					case .text:
+						let content = String(buffer: frame.data)
 						incomingMessage = try await bskyMessageManager.processMessage(string: content)
-					@unknown default:
+
+					case .connectionClose:
+						// Handle a received close frame. We're just going to close by returning from this method.
+						print("Received Close instruction from server")
+						return
+					case .binary, .continuation, .ping:
+						let data = Data(buffer: frame.data)
+						incomingMessage = try await bskyMessageManager.processMessage(content: data)
+					default:
 						throw BskyMessageManagerError.nonValidMessage
 				}
 				
 				if let onMessageReceived, let incomingMessage {
 					onMessageReceived(incomingMessage)
 				}
-			} catch BskyMessageManagerError.unprocessable(let messageData) {
-				let unknownMessage = BskyMessage.unknown(message: messageData)
-				onMessageReceived?(unknownMessage)
-			} catch {
-				onErrorProcessingMessage?(.invalidMessage(content: message))
 			}
 		}
-		
-		await Task.yield()
-				
-		try await processIncomingMessage()
 	}
 	
 	public func onMessageReceived(_ perform: @escaping @Sendable MessageReceivedClosure) {
@@ -108,5 +169,10 @@ extension BskyFirehoseClient {
 	enum Status {
 		case connected
 		case closed
+	}
+	
+	enum UpgradeResult {
+		case websocket(NIOAsyncChannel<WebSocketFrame, WebSocketFrame>)
+		case notUpgraded
 	}
 }

--- a/Sources/Monarca/BskyFirehoseClient.swift
+++ b/Sources/Monarca/BskyFirehoseClient.swift
@@ -46,13 +46,13 @@ public final class BskyFirehoseClient: Sendable {
 			throw BskyFirehoseError.invalidConnectionParameters
 		}
 		
-		WebSocket.connect(to: bskyURL, on: eventLoopGroup) { [unowned self] ws in
+		WebSocket.connect(to: bskyURL, on: eventLoopGroup) { [weak self] ws in
 			ws.onText { ws, content in
 				do {
 					let incomingMessage = try await bskyMessageManager.processMessage(string: content)
-					self.onMessageReceived?(incomingMessage)
+					self?.onMessageReceived?(incomingMessage)
 				} catch {
-					self.onErrorProcessingMessage?(.invalidMessage(content: .string(content)))
+					self?.onErrorProcessingMessage?(.invalidMessage(content: .string(content)))
 				}
 			}
 			
@@ -61,9 +61,9 @@ public final class BskyFirehoseClient: Sendable {
 				
 				do {
 					let incomingMessage = try await bskyMessageManager.processMessage(content: bytes)
-					self.onMessageReceived?(incomingMessage)
+					self?.onMessageReceived?(incomingMessage)
 				} catch {
-					self.onErrorProcessingMessage?(.invalidMessage(content: .data(bytes)))
+					self?.onErrorProcessingMessage?(.invalidMessage(content: .data(bytes)))
 				}
 			}
 		}

--- a/Sources/Monarca/BskyFirehoseClientBuilder.swift
+++ b/Sources/Monarca/BskyFirehoseClientBuilder.swift
@@ -7,15 +7,29 @@
 
 
 public protocol BskyFirehoseClientBuilder {
+	@available(*, deprecated, renamed: "connect(to:)")
     func withHost(_ server: FireshoseHost) -> Self
+	func connect(to host: FireshoseHost) -> Self
+	@available(*, deprecated, renamed: "forCollections(_:)")
 	func withCollections(_ collection: [String]) -> Self
-	func withCollections(_ collection: [Collection]) -> Self
+	func forCollections(_ collection: [BskyCollection]) -> Self
 	func withDecentralizedIdentifiers(_ identifiers: [String]) -> Self
+	@available(*, deprecated, renamed: "withMaximumMessageSize(_:)")
 	func withMaximumMessageSize(_ size: MessageSize) -> Self
+	func maximumMessageSizeAllowed(_ size: MessageSize) -> Self
+	@available(*, deprecated, renamed: "messagesPlayback(since:)")
 	func withPlayback(_ playback: Playback) -> Self
+	func messagesPlayback(since moment: Playback) -> Self
+	@available(*, deprecated, renamed: "compressionEnabled(_:)")
 	func withCompressionEnabled(_ value: Bool) -> Self
+	func compressionEnabled(_ value: Bool) -> Self
 	func withHelloExecution(_ value: Bool) -> Self
+	@available(*, deprecated, renamed: "useCustomMessageManager(_:)")
 	func withMessageManager(_ messageManager: BskyMessageManager) -> Self
+	func useCustomMessageManager(_ messageManager: BskyMessageManager) -> Self
+	func dedicatedThreads(count: Int) -> Self
+	func applyContentFilter(by terms: [String]) -> Self
+	func applyHashtagFilter(by hashtags: [String]) -> Self
     
     func reset()
 	func build() throws -> BskyFirehoseClient

--- a/Sources/Monarca/BskyFirehoseClientBuilder.swift
+++ b/Sources/Monarca/BskyFirehoseClientBuilder.swift
@@ -7,16 +7,16 @@
 
 
 public protocol BskyFirehoseClientBuilder {
-    func withHost(_ server: FireshoseHost) async -> Self
-	func withCollections(_ collection: [String]) async -> Self
-	func withCollections(_ collection: [Collection]) async -> Self
-	func withDecentralizedIdentifiers(_ identifiers: [String]) async -> Self
-	func withMaximumMessageSize(_ size: MessageSize) async -> Self
-	func withPlayback(_ playback: Playback) async -> Self
-	func withCompressionEnabled(_ value: Bool) async -> Self
-	func withHelloExecution(_ value: Bool) async -> Self
-	func withMessageManager(_ messageManager: BskyMessageManager) async -> Self
+    func withHost(_ server: FireshoseHost) -> Self
+	func withCollections(_ collection: [String]) -> Self
+	func withCollections(_ collection: [Collection]) -> Self
+	func withDecentralizedIdentifiers(_ identifiers: [String]) -> Self
+	func withMaximumMessageSize(_ size: MessageSize) -> Self
+	func withPlayback(_ playback: Playback) -> Self
+	func withCompressionEnabled(_ value: Bool) -> Self
+	func withHelloExecution(_ value: Bool) -> Self
+	func withMessageManager(_ messageManager: BskyMessageManager) -> Self
     
-    func reset() async 
-	func build() async throws -> BskyFirehoseClient
+    func reset()
+	func build() throws -> BskyFirehoseClient
 }

--- a/Sources/Monarca/BskyFirehoseClientBuilder.swift
+++ b/Sources/Monarca/BskyFirehoseClientBuilder.swift
@@ -6,16 +6,17 @@
 //
 
 
-public protocol BskyFirehoseClientBuilder: Sendable {
+public protocol BskyFirehoseClientBuilder {
     func withHost(_ server: FireshoseHost) async -> Self
-    func withCollections(_ collection: [String]) async -> Self
-    func withDecentralizedIdentifiers(_ identifiers: [String]) async -> Self
-    func withMaximumMessageSize(_ size: MessageSize) async -> Self
-    func withPlayback(_ playback: Playback) async -> Self
-    func withCompressionEnabled(_ value: Bool) async -> Self
-    func withHelloExecution(_ value: Bool) async -> Self
+	func withCollections(_ collection: [String]) async -> Self
+	func withCollections(_ collection: [Collection]) async -> Self
+	func withDecentralizedIdentifiers(_ identifiers: [String]) async -> Self
+	func withMaximumMessageSize(_ size: MessageSize) async -> Self
+	func withPlayback(_ playback: Playback) async -> Self
+	func withCompressionEnabled(_ value: Bool) async -> Self
+	func withHelloExecution(_ value: Bool) async -> Self
 	func withMessageManager(_ messageManager: BskyMessageManager) async -> Self
     
-    mutating func reset() async 
-    func build() async throws -> BskyFirehoseClient
+    func reset() async 
+	func build() async throws -> BskyFirehoseClient
 }

--- a/Sources/Monarca/BskyFirehoseError.swift
+++ b/Sources/Monarca/BskyFirehoseError.swift
@@ -12,7 +12,14 @@ public enum BskyFirehoseError: Error {
 	case invalidConnectionParameters
 	case invalidData
 	case messageManagerNotAvailable
-	case invalidMessage(content: URLSessionWebSocketTask.Message)
+	case invalidMessage(content: BskyFirehoseError.Content)
+}
+
+extension BskyFirehoseError {
+	public enum Content: Sendable {
+		case string(_ value: String)
+		case data(_ value: Data)
+	}
 }
 
 extension BskyFirehoseError: Equatable {

--- a/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
+++ b/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
@@ -14,66 +14,66 @@ public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 		settings = BskyFirehoseSettings()
 	}
     
-	public func withHost(_ server: FireshoseHost) async -> Self {
+	public func withHost(_ server: FireshoseHost) -> Self {
 		settings.set(host: server)
         return self
     }
     
 	@available(*, deprecated, message: "Use the `withCollections(_: [Collection])` method instead.")
-	public func withCollections(_ collection: [String]) async -> Self {
+	public func withCollections(_ collection: [String]) -> Self {
 		settings.set(collections: collection)
         return self
     }
 	
-	public func withCollections(_ collection: [Collection]) async -> Self {
+	public func withCollections(_ collection: [Collection]) -> Self {
 		let collectionsRawValues = collection.map { $0.rawValue }
 		settings.set(collections: collectionsRawValues)
 		
 		return self
 	}
     
-	public func withDecentralizedIdentifiers(_ identifiers: [String]) async -> Self {
+	public func withDecentralizedIdentifiers(_ identifiers: [String]) -> Self {
 		settings.set(decentralizedIdentifiers: identifiers)
         return self
     }
     
-	public func withMaximumMessageSize(_ size: MessageSize) async -> Self {
+	public func withMaximumMessageSize(_ size: MessageSize) -> Self {
 		settings.set(maximumMessageSize: size)
         return self
     }
     
-	public func withPlayback(_ playback: Playback) async -> Self {
+	public func withPlayback(_ playback: Playback) -> Self {
 		settings.set(playback: playback)
         return self
     }
     
-	public func withCompressionEnabled(_ value: Bool) async -> Self {
+	public func withCompressionEnabled(_ value: Bool) -> Self {
 		settings.set(isCompressionEnabled: value)
         return self
     }
     
-	public func withHelloExecution(_ value: Bool) async -> Self {
+	public func withHelloExecution(_ value: Bool) -> Self {
 		settings.set(isHelloRequired: value)
         return self
     }
 	
-	public func withMessageManager(_ messageManager: any BskyMessageManager) async -> Self {
+	public func withMessageManager(_ messageManager: any BskyMessageManager) -> Self {
 		settings.set(messageManager: messageManager)
 		return self
 	}
     
-    public func reset() async {
-		await settings.reset()
+    public func reset() {
+		settings.reset()
     }
     
 	
-	public func build() async throws(BskyFirehoseError) -> BskyFirehoseClient {
+	public func build() throws(BskyFirehoseError) -> BskyFirehoseClient {
 		guard let _ = settings.host else {
 			throw BskyFirehoseError.invalidConnectionParameters
 		}
 		
 		if settings.messageManager == nil {
-			await settings.set(messageManager: AllMessagesManager())
+			settings.set(messageManager: AllMessagesManager())
 		}
 		
 		return BskyFirehoseClient(settings: settings)

--- a/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
+++ b/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
@@ -9,24 +9,20 @@ import Foundation
 
 public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 	private var settings: BskyFirehoseSettings
+	private var filterMessageHandler: [any BskyMessageHandler]
 	
 	public init() {
 		settings = BskyFirehoseSettings()
+		filterMessageHandler = []
 	}
-    
-	public func withHost(_ server: FireshoseHost) -> Self {
-		settings.set(host: server)
-        return self
-    }
-    
-	@available(*, deprecated, message: "Use the `withCollections(_: [Collection])` method instead.")
-	public func withCollections(_ collection: [String]) -> Self {
-		settings.set(collections: collection)
-        return self
-    }
 	
-	public func withCollections(_ collection: [Collection]) -> Self {
-		let collectionsRawValues = collection.map { $0.rawValue }
+	public func connect(to host: FireshoseHost) -> Self {
+		settings.set(host: host)
+		return self
+	}
+	
+	public func forCollections(_ collection: [BskyCollection]) -> Self {
+		let collectionsRawValues = collection.map { $0.description }
 		settings.set(collections: collectionsRawValues)
 		
 		return self
@@ -36,37 +32,52 @@ public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 		settings.set(decentralizedIdentifiers: identifiers)
         return self
     }
-    
-	public func withMaximumMessageSize(_ size: MessageSize) -> Self {
+	
+	public func maximumMessageSizeAllowed(_ size: MessageSize) -> Self {
 		settings.set(maximumMessageSize: size)
-        return self
-    }
+		return self
+	}
     
-	public func withPlayback(_ playback: Playback) -> Self {
-		settings.set(playback: playback)
-        return self
-    }
+	public func messagesPlayback(since moment: Playback) -> Self {
+		settings.set(playback: moment)
+		return self
+	}
     
-	public func withCompressionEnabled(_ value: Bool) -> Self {
+	public func compressionEnabled(_ value: Bool) -> Self {
 		settings.set(isCompressionEnabled: value)
-        return self
-    }
+		return self
+	}
     
 	public func withHelloExecution(_ value: Bool) -> Self {
 		settings.set(isHelloRequired: value)
         return self
     }
 	
-	public func withMessageManager(_ messageManager: any BskyMessageManager) -> Self {
+	public func useCustomMessageManager(_ messageManager: any BskyMessageManager) -> Self {
 		settings.set(messageManager: messageManager)
+		return self
+	}
+	
+	public func dedicatedThreads(count: Int) -> Self {
+		settings.set(dedicatedThreads: count)
+		return self
+	}
+	
+	public func applyContentFilter(by terms: [String]) -> Self {
+		filterMessageHandler.append(ContentFilteredCommitMessageHandler(by: terms))
+		return self
+	}
+	
+	public func applyHashtagFilter(by hashtags: [String]) -> Self {
+		filterMessageHandler.append(HashtagFilteredCommitMessageHandler(by: hashtags))
 		return self
 	}
     
     public func reset() {
 		settings.reset()
+		filterMessageHandler.removeAll()
     }
     
-	
 	public func build() throws(BskyFirehoseError) -> BskyFirehoseClient {
 		guard let _ = settings.host else {
 			throw BskyFirehoseError.invalidConnectionParameters
@@ -76,6 +87,49 @@ public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 			settings.set(messageManager: AllMessagesManager())
 		}
 		
+		if filterMessageHandler.isEmpty == false {
+			if let collections = settings.collections {
+				if (collections.isEmpty || collections.contains(BskyCollection.post.description)) {
+					settings.messageManager?.addMessageHandlerFilters(filterMessageHandler)
+				}
+			} else {
+				settings.messageManager?.addMessageHandlerFilters(filterMessageHandler)
+			}
+		}
+	
 		return BskyFirehoseClient(settings: settings)
     }
+}
+
+extension DefaultFirehoseClientBuilder {
+	@available(*, deprecated, renamed: "connect(to:)")
+	public func withHost(_ server: FireshoseHost) -> Self {
+		return connect(to: server)
+	}
+	
+	@available(*, deprecated, renamed: "forCollections(_:)")
+	public func withCollections(_ collection: [String]) -> Self {
+		settings.set(collections: collection)
+		return self
+	}
+	
+	@available(*, deprecated, renamed: "withMaximumMessageSize(_:)")
+	public func withMaximumMessageSize(_ size: MessageSize) -> Self {
+		return maximumMessageSizeAllowed(size)
+	}
+	
+	@available(*, deprecated, renamed: "messagesPlayback(since:)")
+	public func withPlayback(_ playback: Playback) -> Self {
+		return messagesPlayback(since: playback)
+	}
+	
+	@available(*, deprecated, renamed: "compressionEnabled(_:)")
+	public func withCompressionEnabled(_ value: Bool) -> Self {
+		return compressionEnabled(value)
+	}
+	
+	@available(*, deprecated, renamed: "useCustomMessageManager(_:)")
+	public func withMessageManager(_ messageManager: any BskyMessageManager) -> Self {
+		return useCustomMessageManager(messageManager)
+	}
 }

--- a/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
+++ b/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
@@ -9,8 +9,6 @@ import Foundation
 
 public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 	private var settings: BskyFirehoseSettings
-	private var onMessageReceived: MessageReceivedClosure?
-	private var onErrorProcessingMessage: ErrorReceivedClosure?
 	
 	public init() {
 		settings = BskyFirehoseSettings()
@@ -63,16 +61,6 @@ public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 		settings.set(messageManager: messageManager)
 		return self
 	}
-	
-	public func onMessageReceived(_ closure: @escaping MessageReceivedClosure) -> Self {
-		onMessageReceived = closure
-		return self
-	}
-	
-	public func onErrorProcessingMessage(_ closure: @escaping ErrorReceivedClosure) -> Self {
-		onErrorProcessingMessage = closure
-		return self
-	}
     
     public func reset() async {
 		await settings.reset()
@@ -88,8 +76,6 @@ public final class DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 			await settings.set(messageManager: AllMessagesManager())
 		}
 		
-		return BskyFirehoseClient(settings: settings,
-								  onMessageReceived: onMessageReceived,
-								  onErrorProcessingMessage: onErrorProcessingMessage)
+		return BskyFirehoseClient(settings: settings)
     }
 }

--- a/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
+++ b/Sources/Monarca/DefaultFirehoseClientsBuilder.swift
@@ -23,6 +23,13 @@ public struct DefaultFirehoseClientBuilder: BskyFirehoseClientBuilder {
 		await settings.set(collections: collection)
         return self
     }
+	
+	public func withCollections(_ collection: [Collection]) async -> Self {
+		let collectionsRawValues = collection.map { $0.rawValue }
+		await settings.set(collections: collectionsRawValues)
+		
+		return self
+	}
     
     public func withDecentralizedIdentifiers(_ identifiers: [String]) async -> Self {
 		await settings.set(decentralizedIdentifiers: identifiers)

--- a/Sources/Monarca/Entities/BskyCollection.swift
+++ b/Sources/Monarca/Entities/BskyCollection.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-//public typealias A = BskyCollection
+@available(*, deprecated, renamed: "BskyCollection", message: "This enumeration will be removed in future release. Use `BskyCollection` instead.")
+public typealias Collection = BskyCollection
 
 public enum BskyCollection: String, Codable, Sendable {
 	case repost = "app.bsky.feed.repost"
@@ -18,4 +19,10 @@ public enum BskyCollection: String, Codable, Sendable {
 	case block = "app.bsky.graph.block"
 	case post = "app.bsky.feed.post"
 	case starterPack = "app.bsky.graph.starterpack"
+}
+
+extension BskyCollection: CustomStringConvertible {
+	public var description: String {
+		rawValue
+	}
 }

--- a/Sources/Monarca/Entities/BskyCollection.swift
+++ b/Sources/Monarca/Entities/BskyCollection.swift
@@ -19,6 +19,8 @@ public enum BskyCollection: String, Codable, Sendable {
 	case block = "app.bsky.graph.block"
 	case post = "app.bsky.feed.post"
 	case starterPack = "app.bsky.graph.starterpack"
+	case threadGate = "app.bsky.feed.threadgate"
+	case postGate = "app.bsky.feed.postgate"
 }
 
 extension BskyCollection: CustomStringConvertible {

--- a/Sources/Monarca/Entities/BskyCollection.swift
+++ b/Sources/Monarca/Entities/BskyCollection.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-public enum Collection: String, Codable, Sendable {
+//public typealias A = BskyCollection
+
+public enum BskyCollection: String, Codable, Sendable {
 	case repost = "app.bsky.feed.repost"
 	case like = "app.bsky.feed.like"
 	case follow = "app.bsky.graph.follow"

--- a/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
+++ b/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
@@ -54,7 +54,7 @@ public struct BskyFirehoseSettings: Sendable {
 		self.dedicatedThreads = dedicatedThreads
 	}
 	
-	mutating func reset() async {
+	mutating func reset() {
 		host = nil
 		collections = nil
 		decentralizedIdentifiers = nil

--- a/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
+++ b/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
@@ -63,6 +63,7 @@ public struct BskyFirehoseSettings: Sendable {
 		isCompressionEnabled = nil
 		isHelloRequired = nil
 		messageManager = nil
+		dedicatedThreads = 2
 	}
 }
 

--- a/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
+++ b/Sources/Monarca/Entities/Firehose/BskyFirehoseSettings.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public actor BskyFirehoseSettings: Sendable {
+public struct BskyFirehoseSettings: Sendable {
     public internal(set) var host: FireshoseHost?
 	public internal(set) var collections: [String]?
 	public internal(set) var decentralizedIdentifiers: [String]?
@@ -16,40 +16,45 @@ public actor BskyFirehoseSettings: Sendable {
 	public internal(set) var isCompressionEnabled: Bool?
 	public internal(set) var isHelloRequired: Bool?
 	public internal(set) var messageManager: (any BskyMessageManager)?
+	public internal(set) var dedicatedThreads = 2
 	
-	func set(host: FireshoseHost) {
+	mutating func set(host: FireshoseHost) {
 		self.host = host
 	}
 	
-	func set(collections: [String]) {
+	mutating func set(collections: [String]) {
 		self.collections = collections
 	}
 	
-	func set(decentralizedIdentifiers: [String]) {
+	mutating func set(decentralizedIdentifiers: [String]) {
 		self.decentralizedIdentifiers = decentralizedIdentifiers
 	}
 	
-	func set(maximumMessageSize: MessageSize) {
+	mutating func set(maximumMessageSize: MessageSize) {
 		self.maximumMessageSize = maximumMessageSize
 	}
 	
-	func set(playback: Playback) {
+	mutating func set(playback: Playback) {
 		self.playback = playback
 	}
 	
-	func set(isCompressionEnabled: Bool) {
+	mutating func set(isCompressionEnabled: Bool) {
 		self.isCompressionEnabled = isCompressionEnabled
 	}
 	
-	func set(isHelloRequired: Bool) {
+	mutating func set(isHelloRequired: Bool) {
 		self.isHelloRequired = isHelloRequired
 	}
 	
-	func set(messageManager: some BskyMessageManager) {
+	mutating func set(messageManager: some BskyMessageManager) {
 		self.messageManager = messageManager
 	}
 	
-	func reset() async {
+	mutating func set(dedicatedThreads: Int) {
+		self.dedicatedThreads = dedicatedThreads
+	}
+	
+	mutating func reset() async {
 		host = nil
 		collections = nil
 		decentralizedIdentifiers = nil
@@ -64,8 +69,8 @@ public actor BskyFirehoseSettings: Sendable {
 extension BskyFirehoseSettings {
 	public static var defaultWestCoast: Self {
 		get async {
-			let settings = Self.init()
-			await settings.set(host: .usaWest1)
+			var settings = Self.init()
+			settings.set(host: .usaWest1)
 			
 			return settings
 		}
@@ -73,8 +78,8 @@ extension BskyFirehoseSettings {
     
     public static var defaultEastCoast: Self {
 		get async {
-			let settings = Self.init()
-			await settings.set(host: .usaEast1)
+			var settings = Self.init()
+			settings.set(host: .usaEast1)
 			
 			return settings
 		}
@@ -113,9 +118,12 @@ extension BskyFirehoseSettings: @preconcurrency CustomStringConvertible {
 			settingsContent.append("Hello command: \(isHelloRequired)")
 		}
 		
+		settingsContent.append("Dedicated threads: \(dedicatedThreads)")
+		
 		if settingsContent.isEmpty {
 			return "⚠️ No settings provided."
 		}
+		
 		
 		return settingsContent.joined(separator: "\n")
 	}

--- a/Sources/Monarca/Entities/Messages/Account.swift
+++ b/Sources/Monarca/Entities/Messages/Account.swift
@@ -10,10 +10,10 @@ import Foundation
 extension BskyMessage {
 	public struct Account: Codable, Sendable {
 		public struct Payload: Codable, Sendable {
-			let isActive: Bool
-			let did: String
-			let sequence: Int
-			let createdAt: Date
+			public let isActive: Bool
+			public let did: String
+			public let sequence: Int
+			public let createdAt: Date
 			
 			private enum CodingKeys: String, CodingKey {
 				case isActive = "active"
@@ -23,10 +23,10 @@ extension BskyMessage {
 			}
 		}
 		
-		let did: String
-		let createdAt: Int
-		let kind: String
-		let payload: BskyMessage.Account.Payload
+		public let did: String
+		public let createdAt: Int
+		public let kind: String
+		public let payload: BskyMessage.Account.Payload
 		
 		private enum CodingKeys: String, CodingKey {
 			case did

--- a/Sources/Monarca/Entities/Messages/Commit.swift
+++ b/Sources/Monarca/Entities/Messages/Commit.swift
@@ -80,15 +80,17 @@ extension BskyMessage.Commit {
 						if let data = try? values.decode(Record.Post.self, forKey: .record) {
 							decodedRecord = .post(payload: data)
 						}
-						
-						do {
-							try values.decode(Record.Post.self, forKey: .record)
-						} catch {
-							print("🚨 \(error)")
-						}
 					case .starterPack:
 						if let data = try? values.decode(Record.StarterPack.self, forKey: .record) {
 							decodedRecord = .starterPack(payload: data)
+						}
+					case .threadGate:
+						if let data = try? values.decode(Record.ThreadGate.self, forKey: .record) {
+							decodedRecord = .threadGate(payload: data)
+						}
+					case .postGate:
+						if let data = try? values.decode(Record.PostGate.self, forKey: .record) {
+							decodedRecord = .postGate(payload: data)
 						}
 				}
 			} catch {

--- a/Sources/Monarca/Entities/Messages/Commit.swift
+++ b/Sources/Monarca/Entities/Messages/Commit.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension BskyMessage {
 	public struct Commit: Codable, Sendable {
-		let did: String
-		let createdAt: Int
-		let kind: String
-		let payload: BskyMessage.Commit.Payload
+		public let did: String
+		public let createdAt: Int
+		public let kind: String
+		public let payload: BskyMessage.Commit.Payload
 		
 		private enum CodingKeys: String, CodingKey {
 			case did
@@ -25,11 +25,11 @@ extension BskyMessage {
 
 extension BskyMessage.Commit {
 	public struct Payload: Codable, Sendable {
-		let cid: String?
-		let operation: BskyMessage.Commit.Operation
-		let collection: Collection
-		let relatedKey: String
-		let record: Record?
+		public let cid: String?
+		public let operation: BskyMessage.Commit.Operation
+		public let collection: Collection
+		public let relatedKey: String
+		public let record: Record?
 		
 		private enum CodingKeys: String, CodingKey {
 			case cid

--- a/Sources/Monarca/Entities/Messages/Commit.swift
+++ b/Sources/Monarca/Entities/Messages/Commit.swift
@@ -27,7 +27,7 @@ extension BskyMessage.Commit {
 	public struct Payload: Codable, Sendable {
 		public let cid: String?
 		public let operation: BskyMessage.Commit.Operation
-		public let collection: Collection
+		public let collection: BskyCollection
 		public let relatedKey: String
 		public let record: Record?
 		
@@ -49,7 +49,7 @@ extension BskyMessage.Commit {
 			var decodedRecord: Record? = nil
 			
 			do {
-				collection = try values.decode(Collection.self, forKey: .collection)
+				collection = try values.decode(BskyCollection.self, forKey: .collection)
 				
 				switch collection {
 					case .repost:
@@ -79,6 +79,12 @@ extension BskyMessage.Commit {
 					case .post:
 						if let data = try? values.decode(Record.Post.self, forKey: .record) {
 							decodedRecord = .post(payload: data)
+						}
+						
+						do {
+							try values.decode(Record.Post.self, forKey: .record)
+						} catch {
+							print("🚨 \(error)")
 						}
 					case .starterPack:
 						if let data = try? values.decode(Record.StarterPack.self, forKey: .record) {

--- a/Sources/Monarca/Entities/Messages/Identity.swift
+++ b/Sources/Monarca/Entities/Messages/Identity.swift
@@ -10,10 +10,10 @@ import Foundation
 extension BskyMessage {
     public struct Identity: Codable, Sendable {
         public struct Payload: Codable, Sendable {
-            let did: String
-            let userHandle: String
-            let sequence: Int
-            let createdAt: Date 
+            public let did: String
+            public let userHandle: String
+			public let sequence: Int
+			public let createdAt: Date
             
             private enum CodingKeys: String, CodingKey {
                 case did
@@ -23,10 +23,10 @@ extension BskyMessage {
             }
         }
         
-        let did: String
-        let createdAt: Int    
-        let kind: String
-        let payload: BskyMessage.Identity.Payload 
+		public let did: String
+		public let createdAt: Int
+		public let kind: String
+		public let payload: BskyMessage.Identity.Payload 
         
         private enum CodingKeys: String, CodingKey {
             case did

--- a/Sources/Monarca/Entities/Messages/Records/Post.swift
+++ b/Sources/Monarca/Entities/Messages/Records/Post.swift
@@ -30,9 +30,11 @@ extension Record {
 extension Record.Post {
 	public struct Embedded: Codable, Sendable {
 		public let images: [Record.Post.PostImage]?
+		public let video: Record.Post.PostVideo?
 		
 		private enum CodingKeys: String, CodingKey {
 			case images
+			case video
 		}
 	}
 	
@@ -44,6 +46,18 @@ extension Record.Post {
 		private enum CodingKeys: String, CodingKey {
 			case alternateText = "alt"
 			case image
+			case aspectRatio
+		}
+	}
+	
+	public struct PostVideo: Codable, Sendable {
+		public let alternateText: String?
+		public let video: Record.Video
+		public let aspectRatio: Record.AspectRatio?
+		
+		private enum CodingKeys: String, CodingKey {
+			case alternateText = "alt"
+			case video
 			case aspectRatio
 		}
 	}

--- a/Sources/Monarca/Entities/Messages/Records/PostGate.swift
+++ b/Sources/Monarca/Entities/Messages/Records/PostGate.swift
@@ -1,0 +1,26 @@
+//
+//  PostGate.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 5/7/25.
+//
+
+import Foundation
+
+extension Record {
+	public struct PostGate: Codable, Sendable {
+		public let createdAt: Date
+		public let postDid: String
+		public let embeddingRules: [Record.PostGate.Rule]
+	}
+}
+
+extension Record.PostGate {
+	public struct Rule: Codable, Sendable {
+		public let type: String
+		
+		private enum CodingKeys: String, CodingKey {
+			case type = "$type"
+		}
+	}
+}

--- a/Sources/Monarca/Entities/Messages/Records/Record.swift
+++ b/Sources/Monarca/Entities/Messages/Records/Record.swift
@@ -16,6 +16,8 @@ public enum Record: Codable, Sendable {
 	case profile(payload: Record.Profile)
 	case post(payload: Record.Post)
 	case starterPack(payload: Record.StarterPack)
+	case threadGate(payload: Record.ThreadGate)
+	case postGate(payload: Record.PostGate)
 }
 
 

--- a/Sources/Monarca/Entities/Messages/Records/Reference.swift
+++ b/Sources/Monarca/Entities/Messages/Records/Reference.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Record {
 	struct Reference: Codable, Sendable {
-		let atProtocolLink: String
+		public let atProtocolLink: String
 		
 		private enum CodingKeys: String, CodingKey {
 			case atProtocolLink = "$link"

--- a/Sources/Monarca/Entities/Messages/Records/ThreadGate.swift
+++ b/Sources/Monarca/Entities/Messages/Records/ThreadGate.swift
@@ -1,0 +1,32 @@
+//
+//  ThreadGate.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 5/7/25.
+//
+
+import Foundation
+
+extension Record {
+	public struct ThreadGate: Codable, Sendable {
+		public let createdAt: Date
+		public let postDid: String
+		public let allow: [Record.ThreadGate.AllowType]
+		
+		private enum CodingKeys: String, CodingKey {
+			case createdAt
+			case postDid = "post"
+			case allow
+		}
+	}
+}
+
+extension Record.ThreadGate {
+	public struct AllowType: Codable, Sendable {
+		public let type: String
+		
+		private enum CodingKeys: String, CodingKey {
+			case type = "$type"
+		}
+	}
+}

--- a/Sources/Monarca/Entities/Messages/Records/Video.swift
+++ b/Sources/Monarca/Entities/Messages/Records/Video.swift
@@ -1,0 +1,30 @@
+//
+//  Video.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 4/7/25.
+//
+
+extension Record {
+	public struct Video: Codable, Sendable {
+		public let mimeType: String
+		public let size: Int
+		public let bskyURL: String
+		
+		private enum CodingKeys: String, CodingKey {
+			case mimeType
+			case size
+			case bskyURL = "ref"
+		}
+		
+		public init(from decoder: Decoder) throws {
+			let values = try decoder.container(keyedBy: CodingKeys.self)
+			
+			mimeType = try values.decode(String.self, forKey: .mimeType)
+			size = try values.decode(Int.self, forKey: .size)
+			
+			let reference = try values.decode(Record.Reference.self, forKey: .bskyURL)
+			bskyURL = reference.atProtocolLink
+		}
+	}
+}

--- a/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
+++ b/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct BskyFirehoseSettingsMapper {
     func mapToURL(from settings: BskyFirehoseSettings) async throws(FirehoseMapperError) -> URL {
-        guard let host = await settings.host,
+        guard let host = settings.host,
               var urlComponents = URLComponents(string: host.endpoint)
         else 
         {
@@ -18,32 +18,32 @@ struct BskyFirehoseSettingsMapper {
         
         var firehoseQueryItems = [URLQueryItem]()
         
-        if let collections = await settings.collections {
+        if let collections = settings.collections {
             let filteredCollections = collections.map { URLQueryItem(name: "wantedCollections", value: $0) }
             firehoseQueryItems.append(contentsOf: filteredCollections)
         }
         
-        if let identifiers = await settings.decentralizedIdentifiers {
+        if let identifiers = settings.decentralizedIdentifiers {
             let filteredIdentifiers = identifiers.map { URLQueryItem(name: "wantedDids", value: $0) }
             firehoseQueryItems.append(contentsOf: filteredIdentifiers)
         }
         
-        if let isCompressionEnabled = await settings.isCompressionEnabled {
+        if let isCompressionEnabled = settings.isCompressionEnabled {
             let filterCompression = URLQueryItem(name: "compress", value: String(isCompressionEnabled))
             firehoseQueryItems.append(filterCompression)
         }
         
-        if let playback = await settings.playback {
+        if let playback = settings.playback {
             let filterPlayback = URLQueryItem(name: "cursor", value: "\(playback.timeValue)")
             firehoseQueryItems.append(filterPlayback)
         }
         
-        if let messageSize = await settings.maximumMessageSize {
+        if let messageSize = settings.maximumMessageSize {
             let filteMessageSize = URLQueryItem(name: "maxMessageSizeBytes", value: "\(messageSize.value)")
             firehoseQueryItems.append(filteMessageSize)
         }
         
-        if let isHelloRequired = await settings.isHelloRequired {
+        if let isHelloRequired = settings.isHelloRequired {
             let filterHelloRequired = URLQueryItem(name: "requireHello", value: String(isHelloRequired))
             firehoseQueryItems.append(filterHelloRequired)
         }

--- a/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
+++ b/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
@@ -58,4 +58,31 @@ struct BskyFirehoseSettingsMapper {
         
         return jetstreamURL
     }
+	
+	func mapToWebSocketBootstrap(from url: URL) -> (host: String, port: Int, path: String)? {
+		let uri = url.absoluteString
+		
+		let urlWithoutProtocol: String
+		let defaultPort: Int
+		
+		if uri.hasPrefix("wss://") {
+			urlWithoutProtocol = String(uri.dropFirst(6))
+			defaultPort = 443
+		} else if uri.hasPrefix("ws://") {
+			urlWithoutProtocol = String(uri.dropFirst(5))
+			defaultPort = 80
+		} else {
+			return nil
+		}
+		
+		let components = urlWithoutProtocol.split(separator: "/", maxSplits: 1)
+		let hostAndPort = String(components[0])
+		let path = components.count > 1 ? "/" + String(components[1]) : "/"
+		
+		let hostComponents = hostAndPort.split(separator: ":")
+		let host = String(hostComponents[0])
+		let port = hostComponents.count > 1 ? Int(String(hostComponents[1])) ?? defaultPort : defaultPort
+		
+		return (host: host, port: port, path: path)
+	}
 }

--- a/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
+++ b/Sources/Monarca/Mappers/BskyFirehoseSettingsMapper.swift
@@ -58,31 +58,4 @@ struct BskyFirehoseSettingsMapper {
         
         return jetstreamURL
     }
-	
-	func mapToWebSocketBootstrap(from url: URL) -> (host: String, port: Int, path: String)? {
-		let uri = url.absoluteString
-		
-		let urlWithoutProtocol: String
-		let defaultPort: Int
-		
-		if uri.hasPrefix("wss://") {
-			urlWithoutProtocol = String(uri.dropFirst(6))
-			defaultPort = 443
-		} else if uri.hasPrefix("ws://") {
-			urlWithoutProtocol = String(uri.dropFirst(5))
-			defaultPort = 80
-		} else {
-			return nil
-		}
-		
-		let components = urlWithoutProtocol.split(separator: "/", maxSplits: 1)
-		let hostAndPort = String(components[0])
-		let path = components.count > 1 ? "/" + String(components[1]) : "/"
-		
-		let hostComponents = hostAndPort.split(separator: ":")
-		let host = String(hostComponents[0])
-		let port = hostComponents.count > 1 ? Int(String(hostComponents[1])) ?? defaultPort : defaultPort
-		
-		return (host: host, port: port, path: path)
-	}
 }

--- a/Sources/Monarca/Subscription/Handlers/AccountMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/AccountMessageHandler.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-actor AccountMessageHandler: Sendable {
+struct AccountMessageHandler {
 	private(set) var nextHandler: (any BskyMessageHandler)?
 }
 
 extension AccountMessageHandler: BskyMessageHandler {
-	func setNextHandler(_ handler: any BskyMessageHandler) {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
 		self.nextHandler = handler
 	}
 	
-	func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+	mutating func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
 		do {
 			let accountMessage = try decoder.decode(BskyMessage.Account.self, from: data)
 			return .account(payload: accountMessage)
 		} catch {
-			guard let nextHandler else {
+			guard var nextHandler else {
 				throw BskyMessageManagerError.unprocessable(message: data)
 			}
 			

--- a/Sources/Monarca/Subscription/Handlers/BskyMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/BskyMessageHandler.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public protocol BskyMessageHandler: Sendable {
-    func setNextHandler(_ handler: any BskyMessageHandler) async
-    func processMessage(content data: Data, using: JSONDecoder) async throws -> BskyMessage
+    mutating func setNextHandler(_ handler: any BskyMessageHandler) async
+    mutating func processMessage(content data: Data, using: JSONDecoder) async throws -> BskyMessage
 }

--- a/Sources/Monarca/Subscription/Handlers/BskyMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/BskyMessageHandler.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 public protocol BskyMessageHandler: Sendable {
-    mutating func setNextHandler(_ handler: any BskyMessageHandler) async
+    mutating func setNextHandler(_ handler: any BskyMessageHandler)
     mutating func processMessage(content data: Data, using: JSONDecoder) async throws -> BskyMessage
 }

--- a/Sources/Monarca/Subscription/Handlers/BskyMessageHandlerError.swift
+++ b/Sources/Monarca/Subscription/Handlers/BskyMessageHandlerError.swift
@@ -1,0 +1,12 @@
+//
+//  BskyMessageHandlerError.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 4/7/25.
+//
+
+enum BskyMessageHandlerError: Error {
+	case noHashtagMatch
+	case noContentMatch
+	case noPostCommitMessage
+}

--- a/Sources/Monarca/Subscription/Handlers/CommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/CommitMessageHandler.swift
@@ -7,22 +7,22 @@
 
 import Foundation
 
-actor CommitMessageHandler: Sendable {
+struct CommitMessageHandler {
 	private(set) var nextHandler: (any BskyMessageHandler)?
 }
 
 extension CommitMessageHandler: BskyMessageHandler {
-	func setNextHandler(_ handler: any BskyMessageHandler) {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
 		self.nextHandler = handler
 	}
 	
-	func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+	mutating func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
 		do {
 			let commitMessage = try decoder.decode(BskyMessage.Commit.self, from: data)
 			
 			return .commit(payload: commitMessage)
-		} catch let error {
-			guard let nextHandler else {
+		} catch {
+			guard var nextHandler else {
 				throw BskyMessageManagerError.unprocessable(message: data)
 			}
 			

--- a/Sources/Monarca/Subscription/Handlers/CommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/CommitMessageHandler.swift
@@ -19,6 +19,7 @@ extension CommitMessageHandler: BskyMessageHandler {
 	func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
 		do {
 			let commitMessage = try decoder.decode(BskyMessage.Commit.self, from: data)
+			
 			return .commit(payload: commitMessage)
 		} catch let error {
 			guard let nextHandler else {

--- a/Sources/Monarca/Subscription/Handlers/ContentFilteredCommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/ContentFilteredCommitMessageHandler.swift
@@ -1,0 +1,41 @@
+//
+//  FilteredCommitMessageHandler.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 3/7/25.
+//
+
+import Foundation
+
+struct ContentFilteredCommitMessageHandler {
+	private(set) var nextHandler: (any BskyMessageHandler)?
+	private let filterTerm: String
+	
+	init(by term: String) {
+		filterTerm = term
+	}
+}
+
+extension ContentFilteredCommitMessageHandler: BskyMessageHandler {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
+		self.nextHandler = handler
+	}
+	
+	mutating func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+		do {
+			let commitMessage = try decoder.decode(BskyMessage.Commit.self, from: data)
+			
+			if case let .post(record) = commitMessage.payload.record, record.text.contains(filterTerm) {
+				
+			}
+			
+			return .commit(payload: commitMessage)
+		} catch {
+			guard var nextHandler else {
+				throw BskyMessageManagerError.unprocessable(message: data)
+			}
+			
+			return try await nextHandler.processMessage(content: data, using: decoder)
+		}
+	}
+}

--- a/Sources/Monarca/Subscription/Handlers/FilteredCommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/FilteredCommitMessageHandler.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-actor FilteredCommitMessageHandler {
+struct FilteredCommitMessageHandler {
 	private(set) var nextHandler: (any BskyMessageHandler)?
 	private let filterTerm: String
 	
@@ -17,11 +17,11 @@ actor FilteredCommitMessageHandler {
 }
 
 extension FilteredCommitMessageHandler: BskyMessageHandler {
-	func setNextHandler(_ handler: any BskyMessageHandler) {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
 		self.nextHandler = handler
 	}
 	
-	func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+	mutating func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
 		do {
 			let commitMessage = try decoder.decode(BskyMessage.Commit.self, from: data)
 			
@@ -30,8 +30,8 @@ extension FilteredCommitMessageHandler: BskyMessageHandler {
 			}
 			
 			return .commit(payload: commitMessage)
-		} catch let error {
-			guard let nextHandler else {
+		} catch {
+			guard var nextHandler else {
 				throw BskyMessageManagerError.unprocessable(message: data)
 			}
 			

--- a/Sources/Monarca/Subscription/Handlers/FilteredCommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/FilteredCommitMessageHandler.swift
@@ -1,0 +1,41 @@
+//
+//  FilteredCommitMessageHandler.swift
+//  Monarca
+//
+//  Created by Adolfo Vera Blasco on 3/7/25.
+//
+
+import Foundation
+
+actor FilteredCommitMessageHandler {
+	private(set) var nextHandler: (any BskyMessageHandler)?
+	private let filterTerm: String
+	
+	init(by term: String) {
+		filterTerm = term
+	}
+}
+
+extension FilteredCommitMessageHandler: BskyMessageHandler {
+	func setNextHandler(_ handler: any BskyMessageHandler) {
+		self.nextHandler = handler
+	}
+	
+	func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+		do {
+			let commitMessage = try decoder.decode(BskyMessage.Commit.self, from: data)
+			
+			if case let .post(record) = commitMessage.payload.record, record.text.contains(filterTerm) {
+				
+			}
+			
+			return .commit(payload: commitMessage)
+		} catch let error {
+			guard let nextHandler else {
+				throw BskyMessageManagerError.unprocessable(message: data)
+			}
+			
+			return try await nextHandler.processMessage(content: data, using: decoder)
+		}
+	}
+}

--- a/Sources/Monarca/Subscription/Handlers/HashtagFilteredCommitMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/HashtagFilteredCommitMessageHandler.swift
@@ -1,22 +1,15 @@
-//
-//  FilteredCommitMessageHandler.swift
-//  Monarca
-//
-//  Created by Adolfo Vera Blasco on 3/7/25.
-//
-
 import Foundation
 
-struct FilteredCommitMessageHandler {
+struct HashtagFilteredCommitMessageHandler {
 	private(set) var nextHandler: (any BskyMessageHandler)?
-	private let filterTerm: String
+	private let hashtags: [String]
 	
-	init(by term: String) {
-		filterTerm = term
+	init(by hashtags: [String[]) {
+		self.hashtags = hashtags
 	}
 }
 
-extension FilteredCommitMessageHandler: BskyMessageHandler {
+extension HashtagFilteredCommitMessageHandler: BskyMessageHandler {
 	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
 		self.nextHandler = handler
 	}

--- a/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
@@ -12,7 +12,7 @@ struct IdentityMessageHandler {
 }
 
 extension IdentityMessageHandler: BskyMessageHandler {
-	mutating func setNextHandler(_ handler: any BskyMessageHandler) async {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) {
 		self.nextHandler = handler
 	}
 	

--- a/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-actor IdentityMessageHandler: Sendable {
+struct IdentityMessageHandler {
 	private(set) var nextHandler: (any BskyMessageHandler)?
 }
 
 extension IdentityMessageHandler: BskyMessageHandler {
-	func setNextHandler(_ handler: any BskyMessageHandler) async {
+	mutating func setNextHandler(_ handler: any BskyMessageHandler) async {
 		self.nextHandler = handler
 	}
 	
-    func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
+    mutating func processMessage(content data: Data, using decoder: JSONDecoder) async throws -> BskyMessage {
         do {
             let identityMessage = try decoder.decode(BskyMessage.Identity.self, from: data)
             return .identity(payload: identityMessage)
         } catch {
-            guard let nextHandler else {
+            guard var nextHandler else {
                 throw BskyMessageManagerError.unprocessable(message: data)
             }
             

--- a/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
+++ b/Sources/Monarca/Subscription/Handlers/IdentityMessageHandler.swift
@@ -27,6 +27,5 @@ extension IdentityMessageHandler: BskyMessageHandler {
             
             return try await nextHandler.processMessage(content: data, using: decoder)
         }
-        
     }
 }

--- a/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
+++ b/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-actor AllMessagesManager: BskyMessageManager {
-    private let handlersChain: [any BskyMessageHandler]
+struct AllMessagesManager: BskyMessageManager {
+	private var handlersChain: [any BskyMessageHandler]
     private let jsonDecoder = JSONDecoder()
     
     init() async {
@@ -23,7 +23,7 @@ actor AllMessagesManager: BskyMessageManager {
         try? await buildHandlersChain()
     }
     
-    private func buildHandlersChain() async throws {
+    private mutating func buildHandlersChain() async throws {
         guard handlersChain.isEmpty == false else {
             throw BskyMessageManagerError.unavailableHandlers
         }
@@ -34,7 +34,7 @@ actor AllMessagesManager: BskyMessageManager {
     }
     
     func processMessage(content data: Data) async throws -> BskyMessage {
-		guard let firstHandler = handlersChain.first else {
+		guard var firstHandler = handlersChain.first else {
 			throw BskyMessageManagerError.unavailableHandlers
         }
         

--- a/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
+++ b/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct AllMessagesManager: BskyMessageManager {
-	private var handlersChain: [any BskyMessageHandler]
+	private(set) var handlersChain: [any BskyMessageHandler]
     private let jsonDecoder = JSONDecoder()
     
-    init() {
+	init() {
         handlersChain = [
 			CommitMessageHandler(),
             IdentityMessageHandler(),
@@ -19,6 +19,7 @@ struct AllMessagesManager: BskyMessageManager {
         ]
         
         jsonDecoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+		jsonDecoder.allowsJSON5 = true
         
         try? buildHandlersChain()
     }
@@ -51,5 +52,11 @@ struct AllMessagesManager: BskyMessageManager {
 		}
 		
 		return try await processMessage(content: data)
+	}
+	
+	mutating func addMessageHandlerFilters(_ filters: [any BskyMessageHandler]) {
+		handlersChain.insert(contentsOf: filters, at: 1)
+		
+		try? buildHandlersChain()
 	}
 }

--- a/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
+++ b/Sources/Monarca/Subscription/Manager/AllMessagesManager.swift
@@ -11,7 +11,7 @@ struct AllMessagesManager: BskyMessageManager {
 	private var handlersChain: [any BskyMessageHandler]
     private let jsonDecoder = JSONDecoder()
     
-    init() async {
+    init() {
         handlersChain = [
 			CommitMessageHandler(),
             IdentityMessageHandler(),
@@ -20,16 +20,16 @@ struct AllMessagesManager: BskyMessageManager {
         
         jsonDecoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
         
-        try? await buildHandlersChain()
+        try? buildHandlersChain()
     }
     
-    private mutating func buildHandlersChain() async throws {
+    private mutating func buildHandlersChain() throws {
         guard handlersChain.isEmpty == false else {
             throw BskyMessageManagerError.unavailableHandlers
         }
         
         for index in 0 ..< (handlersChain.count - 1) {
-            await handlersChain[index].setNextHandler(handlersChain[index + 1])
+            handlersChain[index].setNextHandler(handlersChain[index + 1])
         }
     }
     

--- a/Sources/Monarca/Subscription/Manager/BskyMessageManager.swift
+++ b/Sources/Monarca/Subscription/Manager/BskyMessageManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public protocol BskyMessageManager: Sendable {
+	mutating func addMessageHandlerFilters(_ filters: [any BskyMessageHandler])
 	func processMessage(content data: Data) async throws -> BskyMessage
     func processMessage(string value: String) async throws -> BskyMessage
 }

--- a/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
+++ b/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
@@ -42,7 +42,7 @@ struct BuilderTests {
 	func testClientCollections() async throws  {
 		let firehoseClient = try await DefaultFirehoseClientBuilder()
 			.withHost(.usaEast1)
-			.withCollections([])
+			.withCollections([Collection]())
 			.build()
 		
 		#expect(await firehoseClient.settings.collections != nil)

--- a/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
+++ b/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
@@ -24,8 +24,8 @@ struct BuilderTests {
 			.withHost(server)
 			.build()
 		
-		#expect(await firehoseClient.settings.host != nil)
-		#expect(await firehoseClient.settings.host!.endpoint == server.endpoint)
+		#expect(firehoseClient.settings.host != nil)
+		#expect(firehoseClient.settings.host!.endpoint == server.endpoint)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.customServerList)
@@ -34,8 +34,8 @@ struct BuilderTests {
 			.withHost(custom)
 			.build()
 		
-		#expect(await firehoseClient.settings.host != nil)
-		#expect(await firehoseClient.settings.host!.endpoint == custom.endpoint)
+		#expect(firehoseClient.settings.host != nil)
+		#expect(firehoseClient.settings.host!.endpoint == custom.endpoint)
 	}
 	
 	@Test("", .tags(.builder))
@@ -45,8 +45,8 @@ struct BuilderTests {
 			.withCollections([Collection]())
 			.build()
 		
-		#expect(await firehoseClient.settings.collections != nil)
-		#expect(await firehoseClient.settings.collections!.isEmpty)
+		#expect(firehoseClient.settings.collections != nil)
+		#expect(firehoseClient.settings.collections!.isEmpty)
 	}
 	
 	@Test("", .tags(.builder))
@@ -56,11 +56,11 @@ struct BuilderTests {
 			.withCollections([ "a", "b", "c" ])
 			.build()
 		
-		#expect(await firehoseClient.settings.collections != nil)
-		#expect(await firehoseClient.settings.collections!.count == 3)
-		#expect(await firehoseClient.settings.collections!.contains("a"))
-		#expect(await firehoseClient.settings.collections!.contains("b"))
-		#expect(await firehoseClient.settings.collections!.contains("c"))
+		#expect(firehoseClient.settings.collections != nil)
+		#expect(firehoseClient.settings.collections!.count == 3)
+		#expect(firehoseClient.settings.collections!.contains("a"))
+		#expect(firehoseClient.settings.collections!.contains("b"))
+		#expect(firehoseClient.settings.collections!.contains("c"))
 	}
 	
 	@Test("", .tags(.builder))
@@ -70,8 +70,8 @@ struct BuilderTests {
 			.withDecentralizedIdentifiers([])
 			.build()
 		
-		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(await firehoseClient.settings.decentralizedIdentifiers!.isEmpty)
+		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(firehoseClient.settings.decentralizedIdentifiers!.isEmpty)
 	}
 	
 	@Test("", .tags(.builder))
@@ -81,8 +81,8 @@ struct BuilderTests {
 			.withDecentralizedIdentifiers(Constants.customIdentifierList)
 			.build()
 		
-		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(await firehoseClient.settings.decentralizedIdentifiers!.count == Constants.customIdentifierList.count)
+		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(firehoseClient.settings.decentralizedIdentifiers!.count == Constants.customIdentifierList.count)
 	}
 	
 	@Test("", .tags(.builder))
@@ -92,8 +92,8 @@ struct BuilderTests {
 			.withCompressionEnabled(true)
 			.build()
 		
-		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(await firehoseClient.settings.isCompressionEnabled!)
+		#expect(firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(firehoseClient.settings.isCompressionEnabled!)
 	}
 	
 	@Test("", .tags(.builder))
@@ -103,8 +103,8 @@ struct BuilderTests {
 			.withCompressionEnabled(false)
 			.build()
 		
-		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(await firehoseClient.settings.isCompressionEnabled! == false)
+		#expect(firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(firehoseClient.settings.isCompressionEnabled! == false)
 	}
 	
 	@Test("", .tags(.builder))
@@ -114,8 +114,8 @@ struct BuilderTests {
 			.withHelloExecution(true)
 			.build()
 		
-		#expect(await firehoseClient.settings.isHelloRequired != nil)
-		#expect(await firehoseClient.settings.isHelloRequired!)
+		#expect(firehoseClient.settings.isHelloRequired != nil)
+		#expect(firehoseClient.settings.isHelloRequired!)
 	}
 	
 	@Test("", .tags(.builder))
@@ -125,8 +125,8 @@ struct BuilderTests {
 			.withHelloExecution(false)
 			.build()
 		
-		#expect(await firehoseClient.settings.isHelloRequired != nil)
-		#expect(await firehoseClient.settings.isHelloRequired! == false)
+		#expect(firehoseClient.settings.isHelloRequired != nil)
+		#expect(firehoseClient.settings.isHelloRequired! == false)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.messagesSizeList)
@@ -136,8 +136,8 @@ struct BuilderTests {
 			.withMaximumMessageSize(testSet.sut)
 			.build()
 		
-		#expect(await firehoseClient.settings.maximumMessageSize != nil)
-		#expect(await firehoseClient.settings.maximumMessageSize! == testSet.expectedValue)
+		#expect(firehoseClient.settings.maximumMessageSize != nil)
+		#expect(firehoseClient.settings.maximumMessageSize! == testSet.expectedValue)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.playbackList)
@@ -151,9 +151,9 @@ struct BuilderTests {
 			.withPlayback(sut)
 			.build()
 		
-		#expect(await firehoseClient.settings.playback != nil)
-		#expect(await firehoseClient.settings.playback!.timeValue > lowEpochBound)
-		#expect(await firehoseClient.settings.playback!.timeValue < maxEpochBound)
+		#expect(firehoseClient.settings.playback != nil)
+		#expect(firehoseClient.settings.playback!.timeValue > lowEpochBound)
+		#expect(firehoseClient.settings.playback!.timeValue < maxEpochBound)
 	}
 	
 	@Test("", .tags(.builder))
@@ -166,7 +166,7 @@ struct BuilderTests {
 			.withMessageManager(mockMessageManager)
 			.build()
 		
-		#expect(await firehoseClient.settings.messageManager != nil)
+		#expect(firehoseClient.settings.messageManager != nil)
 	}
 	
 	@Test("", .tags(.builder))
@@ -183,13 +183,13 @@ struct BuilderTests {
 			.withPlayback(.seconds(5))
 			.build()
 			
-		#expect(await firehoseClient.settings.host != nil)
-		#expect(await firehoseClient.settings.collections != nil)
-		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(await firehoseClient.settings.isHelloRequired != nil)
-		#expect(await firehoseClient.settings.maximumMessageSize != nil)
-		#expect(await firehoseClient.settings.playback != nil)
+		#expect(firehoseClient.settings.host != nil)
+		#expect(firehoseClient.settings.collections != nil)
+		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(firehoseClient.settings.isHelloRequired != nil)
+		#expect(firehoseClient.settings.maximumMessageSize != nil)
+		#expect(firehoseClient.settings.playback != nil)
 		
 		await builder.reset()
 		
@@ -197,13 +197,13 @@ struct BuilderTests {
 			.withHost(.usaEast1)
 			.build()
 		
-		#expect(await firehoseClient.settings.host != nil)
-		#expect(await firehoseClient.settings.collections == nil)
-		#expect(await firehoseClient.settings.decentralizedIdentifiers == nil)
-		#expect(await firehoseClient.settings.isCompressionEnabled == nil)
-		#expect(await firehoseClient.settings.isHelloRequired == nil)
-		#expect(await firehoseClient.settings.maximumMessageSize == nil)
-		#expect(await firehoseClient.settings.playback == nil)
+		#expect(firehoseClient.settings.host != nil)
+		#expect(firehoseClient.settings.collections == nil)
+		#expect(firehoseClient.settings.decentralizedIdentifiers == nil)
+		#expect(firehoseClient.settings.isCompressionEnabled == nil)
+		#expect(firehoseClient.settings.isHelloRequired == nil)
+		#expect(firehoseClient.settings.maximumMessageSize == nil)
+		#expect(firehoseClient.settings.playback == nil)
 	}
 }
 

--- a/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
+++ b/Tests/MonarcaTests/FirehoseClientBuilderTests.swift
@@ -20,124 +20,138 @@ struct BuilderTests {
 	
 	@Test("", .tags(.builder), arguments: Constants.serverList)
 	func testClientURL(server: FireshoseHost) async throws {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(server)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: server)
 			.build()
 		
-		#expect(firehoseClient.settings.host != nil)
-		#expect(firehoseClient.settings.host!.endpoint == server.endpoint)
+		#expect(await firehoseClient.settings.host != nil)
+		#expect(await firehoseClient.settings.host!.endpoint == server.endpoint)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.customServerList)
 	func testClientCustomURL(_ custom: FireshoseHost) async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(custom)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: custom)
 			.build()
 		
-		#expect(firehoseClient.settings.host != nil)
-		#expect(firehoseClient.settings.host!.endpoint == custom.endpoint)
+		#expect(await firehoseClient.settings.host != nil)
+		#expect(await firehoseClient.settings.host!.endpoint == custom.endpoint)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientCollections() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withCollections([Collection]())
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.forCollections([BskyCollection]())
 			.build()
 		
-		#expect(firehoseClient.settings.collections != nil)
-		#expect(firehoseClient.settings.collections!.isEmpty)
+		#expect(await firehoseClient.settings.collections != nil)
+		#expect(await firehoseClient.settings.collections!.isEmpty)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientCustomCollections() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
 			.withCollections([ "a", "b", "c" ])
 			.build()
 		
-		#expect(firehoseClient.settings.collections != nil)
-		#expect(firehoseClient.settings.collections!.count == 3)
-		#expect(firehoseClient.settings.collections!.contains("a"))
-		#expect(firehoseClient.settings.collections!.contains("b"))
-		#expect(firehoseClient.settings.collections!.contains("c"))
+		#expect(await firehoseClient.settings.collections != nil)
+		#expect(await firehoseClient.settings.collections!.count == 3)
+		#expect(await firehoseClient.settings.collections!.contains("a"))
+		#expect(await firehoseClient.settings.collections!.contains("b"))
+		#expect(await firehoseClient.settings.collections!.contains("c"))
+	}
+	
+	@Test("", .tags(.builder))
+	func testClientBskyCollections() async throws  {
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.forCollections([ .post, .like, .repost ])
+			.build()
+		
+		#expect(await firehoseClient.settings.collections != nil)
+		#expect(await firehoseClient.settings.collections!.count == 3)
+		#expect(await firehoseClient.settings.collections!.contains(BskyCollection.post.description))
+		#expect(await firehoseClient.settings.collections!.contains(BskyCollection.like.description))
+		#expect(await firehoseClient.settings.collections!.contains(BskyCollection.repost.description))
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientIdentifiers() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
 			.withDecentralizedIdentifiers([])
 			.build()
 		
-		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(firehoseClient.settings.decentralizedIdentifiers!.isEmpty)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers!.isEmpty)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientCustomIdentifiers() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
 			.withDecentralizedIdentifiers(Constants.customIdentifierList)
 			.build()
 		
-		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(firehoseClient.settings.decentralizedIdentifiers!.count == Constants.customIdentifierList.count)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers!.count == Constants.customIdentifierList.count)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientCompressionEnabled() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withCompressionEnabled(true)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.compressionEnabled(true)
 			.build()
 		
-		#expect(firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(firehoseClient.settings.isCompressionEnabled!)
+		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(await firehoseClient.settings.isCompressionEnabled!)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientCompressionDisabled() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withCompressionEnabled(false)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.compressionEnabled(false)
 			.build()
 		
-		#expect(firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(firehoseClient.settings.isCompressionEnabled! == false)
+		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(await firehoseClient.settings.isCompressionEnabled! == false)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientHelloCommandEnabled() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
 			.withHelloExecution(true)
 			.build()
 		
-		#expect(firehoseClient.settings.isHelloRequired != nil)
-		#expect(firehoseClient.settings.isHelloRequired!)
+		#expect(await firehoseClient.settings.isHelloRequired != nil)
+		#expect(await firehoseClient.settings.isHelloRequired!)
 	}
 	
 	@Test("", .tags(.builder))
 	func testClientHelloCommandDisabled() async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
 			.withHelloExecution(false)
 			.build()
 		
-		#expect(firehoseClient.settings.isHelloRequired != nil)
-		#expect(firehoseClient.settings.isHelloRequired! == false)
+		#expect(await firehoseClient.settings.isHelloRequired != nil)
+		#expect(await firehoseClient.settings.isHelloRequired! == false)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.messagesSizeList)
 	func testMessageSizeLimit(testSet: (sut: MessageSize, expectedValue: Int)) async throws  {
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withMaximumMessageSize(testSet.sut)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.maximumMessageSizeAllowed(testSet.sut)
 			.build()
 		
-		#expect(firehoseClient.settings.maximumMessageSize != nil)
-		#expect(firehoseClient.settings.maximumMessageSize! == testSet.expectedValue)
+		#expect(await firehoseClient.settings.maximumMessageSize != nil)
+		#expect(await firehoseClient.settings.maximumMessageSize! == testSet.expectedValue)
 	}
 	
 	@Test("", .tags(.builder), arguments: Constants.playbackList)
@@ -146,14 +160,14 @@ struct BuilderTests {
 		let lowEpochBound = currentEpochTimestamp - 50_0000
 		let maxEpochBound = currentEpochTimestamp + 50_0000
 		
-		let firehoseClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withPlayback(sut)
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.messagesPlayback(since: sut)
 			.build()
 		
-		#expect(firehoseClient.settings.playback != nil)
-		#expect(firehoseClient.settings.playback!.timeValue > lowEpochBound)
-		#expect(firehoseClient.settings.playback!.timeValue < maxEpochBound)
+		#expect(await firehoseClient.settings.playback != nil)
+		#expect(await firehoseClient.settings.playback!.timeValue > lowEpochBound)
+		#expect(await firehoseClient.settings.playback!.timeValue < maxEpochBound)
 	}
 	
 	@Test("", .tags(.builder))
@@ -161,49 +175,113 @@ struct BuilderTests {
 		let mockMessageManager = MockMessageManager()
 		let builder = DefaultFirehoseClientBuilder()
 		
-		let firehoseClient = try await builder
-			.withHost(.usaEast1)
-			.withMessageManager(mockMessageManager)
+		let firehoseClient = try builder
+			.connect(to: .usaEast1)
+			.useCustomMessageManager(mockMessageManager)
 			.build()
 		
-		#expect(firehoseClient.settings.messageManager != nil)
+		#expect(await firehoseClient.settings.messageManager != nil)
+		
+		if let testableManager = await firehoseClient.settings.messageManager as? TestableMessageManager {
+			#expect(testableManager.filtersCount == 0)
+		} else {
+			#expect(false, "Default message manager is not TestableMessageManager")
+		}
+	}
+	
+	@Test("", .tags(.builder))
+	func testDedicatedThreads() async throws  {
+		let builder = DefaultFirehoseClientBuilder()
+		
+		let firehoseClient = try builder
+			.connect(to: .usaEast1)
+			.dedicatedThreads(count: 10)
+			.build()
+		
+		#expect(await firehoseClient.settings.dedicatedThreads == 10)
+	}
+	
+	@Test("", .tags(.builder))
+	func testFilterHashtagManagerHandlerCount() async throws {
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.applyHashtagFilter(by: [ "Madrid" ])
+			.build()
+		
+		if let testableManager = await firehoseClient.settings.messageManager as? TestableMessageManager {
+			#expect(testableManager.filtersCount == 4)
+		} else {
+			#expect(false, "Default message manager is not TestableMessageManager")
+		}
+	}
+	
+	@Test("", .tags(.builder))
+	func testFilterContentManagerHandlerCount() async throws {
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.applyContentFilter(by: [ "Madrid" ])
+			.build()
+		
+		if let testableManager = await firehoseClient.settings.messageManager as? TestableMessageManager {
+			#expect(testableManager.filtersCount == 4)
+		} else {
+			#expect(false, "Default message manager is not TestableMessageManager")
+		}
+	}
+	
+	@Test("", .tags(.builder))
+	func testFilterHashtagAndContentManagerHandlerCount() async throws {
+		let firehoseClient = try DefaultFirehoseClientBuilder()
+			.connect(to: .usaEast1)
+			.applyHashtagFilter(by: [ "Madrid" ])
+			.applyContentFilter(by: [ "España" ])
+			.build()
+		
+		if let testableManager = await firehoseClient.settings.messageManager as? TestableMessageManager {
+			#expect(testableManager.filtersCount == 5)
+		} else {
+			#expect(false, "Default message manager is not TestableMessageManager")
+		}
 	}
 	
 	@Test("", .tags(.builder))
 	func testBuilderReset() async throws  {
-		var builder = DefaultFirehoseClientBuilder()
+		let builder = DefaultFirehoseClientBuilder()
 		
-		var firehoseClient  = try await builder
-			.withHost(.usaEast1)
-			.withCollections([ "a", "b", "c" ])
+		var firehoseClient  = try builder
+			.connect(to: .usaEast1)
+			.forCollections([ .post, .repost, .like ])
 			.withDecentralizedIdentifiers(Constants.customIdentifierList)
-			.withCompressionEnabled(false)
+			.compressionEnabled(false)
 			.withHelloExecution(false)
-			.withMaximumMessageSize(.kilobytes(value: 2048))
-			.withPlayback(.seconds(5))
+			.maximumMessageSizeAllowed(.kilobytes(value: 2048))
+			.messagesPlayback(since: .seconds(5))
+			.dedicatedThreads(count: 8)
 			.build()
 			
-		#expect(firehoseClient.settings.host != nil)
-		#expect(firehoseClient.settings.collections != nil)
-		#expect(firehoseClient.settings.decentralizedIdentifiers != nil)
-		#expect(firehoseClient.settings.isCompressionEnabled != nil)
-		#expect(firehoseClient.settings.isHelloRequired != nil)
-		#expect(firehoseClient.settings.maximumMessageSize != nil)
-		#expect(firehoseClient.settings.playback != nil)
+		#expect(await firehoseClient.settings.host != nil)
+		#expect(await firehoseClient.settings.collections != nil)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers != nil)
+		#expect(await firehoseClient.settings.isCompressionEnabled != nil)
+		#expect(await firehoseClient.settings.isHelloRequired != nil)
+		#expect(await firehoseClient.settings.maximumMessageSize != nil)
+		#expect(await firehoseClient.settings.playback != nil)
+		#expect(await firehoseClient.settings.dedicatedThreads == 8)
 		
-		await builder.reset()
+		builder.reset()
 		
-		firehoseClient = try await builder
-			.withHost(.usaEast1)
+		firehoseClient = try builder
+			.connect(to: .usaEast1)
 			.build()
 		
-		#expect(firehoseClient.settings.host != nil)
-		#expect(firehoseClient.settings.collections == nil)
-		#expect(firehoseClient.settings.decentralizedIdentifiers == nil)
-		#expect(firehoseClient.settings.isCompressionEnabled == nil)
-		#expect(firehoseClient.settings.isHelloRequired == nil)
-		#expect(firehoseClient.settings.maximumMessageSize == nil)
-		#expect(firehoseClient.settings.playback == nil)
+		#expect(await firehoseClient.settings.host != nil)
+		#expect(await firehoseClient.settings.collections == nil)
+		#expect(await firehoseClient.settings.decentralizedIdentifiers == nil)
+		#expect(await firehoseClient.settings.isCompressionEnabled == nil)
+		#expect(await firehoseClient.settings.isHelloRequired == nil)
+		#expect(await firehoseClient.settings.maximumMessageSize == nil)
+		#expect(await firehoseClient.settings.playback == nil)
+		#expect(await firehoseClient.settings.dedicatedThreads == 2)
 	}
 }
 

--- a/Tests/MonarcaTests/MapperTests.swift
+++ b/Tests/MonarcaTests/MapperTests.swift
@@ -23,8 +23,8 @@ struct MapperTests {
 	
 	@Test("", .tags(.mapper))
 	func testMapperURL() async throws {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
 		
 		let mapper = BskyFirehoseSettingsMapper()
 			
@@ -35,10 +35,10 @@ struct MapperTests {
 	
 	@Test("", .tags(.mapper))
 	func testMapperSigleValuesInCollectionsURL() async throws {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
-		await settings.set(collections: [ "swift" ])
-		await settings.set(decentralizedIdentifiers: [ "did:97531" ])
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
+		settings.set(collections: [ "swift" ])
+		settings.set(decentralizedIdentifiers: [ "did:97531" ])
 		
 		let mapper = BskyFirehoseSettingsMapper()
 			
@@ -49,10 +49,10 @@ struct MapperTests {
 	
 	@Test("", .tags(.mapper))
 	func testMapperMultipleValuesInCollectionsURL() async throws {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
-		await settings.set(collections: [ "swift" ])
-		await settings.set(decentralizedIdentifiers: [ "did:97531" ])
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
+		settings.set(collections: [ "swift" ])
+		settings.set(decentralizedIdentifiers: [ "did:97531" ])
 		
 		let mapper = BskyFirehoseSettingsMapper()
 			
@@ -63,14 +63,14 @@ struct MapperTests {
 	
 	@Test("", .tags(.mapper))
 	func testMapperFullParametersURL() async throws {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
-		await settings.set(collections: [ "swift", "objc" ])
-		await settings.set(decentralizedIdentifiers: [ "did:97531", "did:13579" ])
-		await settings.set(playback: .seconds(5))
-		await settings.set(maximumMessageSize: .kilobytes(value: 2))
-		await settings.set(isCompressionEnabled: false)
-		await settings.set(isHelloRequired: false)
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
+		settings.set(collections: [ "swift", "objc" ])
+		settings.set(decentralizedIdentifiers: [ "did:97531", "did:13579" ])
+		settings.set(playback: .seconds(5))
+		settings.set(maximumMessageSize: .kilobytes(value: 2))
+		settings.set(isCompressionEnabled: false)
+		settings.set(isHelloRequired: false)
 		
 		let mapper = BskyFirehoseSettingsMapper()
 			

--- a/Tests/MonarcaTests/MessageHandlerTests.swift
+++ b/Tests/MonarcaTests/MessageHandlerTests.swift
@@ -24,7 +24,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(deletedMessage) = message {
@@ -42,7 +42,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(likeMessage) = message {
@@ -66,7 +66,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(repostMessage) = message {
@@ -90,7 +90,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(followMessage) = message {
@@ -114,7 +114,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(listItemMessage) = message {
@@ -138,7 +138,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(blockMessage) = message {
@@ -162,7 +162,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(profileMessage) = message {
@@ -195,7 +195,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(postMessage) = message {
@@ -232,7 +232,7 @@ struct MessageHandlerTests {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
-		let handler = CommitMessageHandler()
+		var handler = CommitMessageHandler()
 		let message = try await handler.processMessage(content: data, using: jsonDecoder)
 		
 		if case let .commit(postMessage) = message {

--- a/Tests/MonarcaTests/MessageHandlerTests.swift
+++ b/Tests/MonarcaTests/MessageHandlerTests.swift
@@ -14,6 +14,7 @@ struct MessageHandlerTests {
 	var jsonDecoder: JSONDecoder {
 		let jsonDecoder = JSONDecoder()
 		jsonDecoder.dateDecodingStrategy = .iso8601WithFractionalSeconds
+		jsonDecoder.allowsJSON5 = true
 		
 		return jsonDecoder
 	}
@@ -228,7 +229,7 @@ struct MessageHandlerTests {
 	
 	@Test("Commit // Post (With Images, Reply and Facets)", .tags(.messageHandler))
 	func testCommitPostWithFacetsDecoding() async throws {
-		guard let data = MockMessages.commitPostWithFacet.data(using: .utf8) else {
+		guard let data = MockMessages.commitPostWithFacetLink.data(using: .utf8) else {
 			throw MessageHandlerTestsError.invalidJSON
 		}
 		
@@ -260,6 +261,102 @@ struct MessageHandlerTests {
 		} else {
 			throw MessageHandlerTestsError.contentNotAvailable
 		}
+	}
+	
+	@Test("Commit // Post with Facet (Hashtag)")
+	func testFilterByHashtag_GivenOne_Success() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = HashtagFilteredCommitMessageHandler(by: [ "MarioKartWorld" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message != nil)
+	}
+	
+	@Test("Commit // Post with Facet (Hashtag)")
+	func testFilterByHashtag_GivenTwoOnlyOneAvailable_Success() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = HashtagFilteredCommitMessageHandler(by: [ "MarioKartWorld", "NonAvailableHashtag" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message != nil)
+	}
+	
+	@Test("Commit // Post with Facet (Hashtag)")
+	func testFilterByHashtag_GivenOneNoAvailable_Failure() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = HashtagFilteredCommitMessageHandler(by: [ "NonAvailableHashtag" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message == nil)
+	}
+	
+	@Test("Commit // Post with Facet (Hashtag)")
+	func testFilterByHashtag_GivenTwoNoneAvailable_Failure() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = HashtagFilteredCommitMessageHandler(by: [ "NonAvailableHashtagOne", "NonAvailableHashtagTwo" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message == nil)
+	}
+	
+	@Test("Commit // Post filter by term")
+	func testFilterByTerm_GivenOne_Success() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = ContentFilteredCommitMessageHandler(by: [ "Kart" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message != nil)
+	}
+	
+	@Test("Commit // Post filter by term")
+	func testFilterByTerm_GivenTwoOnlyOneMatch_Success() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = ContentFilteredCommitMessageHandler(by: [ "Kart", "EstaPalabraNoEstaEnEstePostSeguro" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message != nil)
+	}
+	
+	@Test("Commit // Post filter by term")
+	func testFilterByTerm_GivenTwoBothMatch_Success() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = ContentFilteredCommitMessageHandler(by: [ "Kart", "ghost" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message != nil)
+	}
+	
+	@Test("Commit // Post filter by term")
+	func testFilterByTerm_GivenOneNoMatch_Failure() async throws {
+		guard let data = MockMessages.commitPostWithFacetTag.data(using: .utf8) else {
+			throw MessageHandlerTestsError.invalidJSON
+		}
+		
+		var handler = ContentFilteredCommitMessageHandler(by: [ "EstaPalabraNoEstaEnElPost" ])
+		let message = try? await handler.processMessage(content: data, using: jsonDecoder)
+		
+		#expect(message == nil)
 	}
 }
 

--- a/Tests/MonarcaTests/Mocks/MockMessageManager.swift
+++ b/Tests/MonarcaTests/Mocks/MockMessageManager.swift
@@ -8,12 +8,34 @@
 import Foundation
 @testable import Monarca
 
+protocol TestableMessageManager {
+	var filtersCount: Int { get }
+}
+
 struct MockMessageManager: BskyMessageManager {
+	var mockFilters: [any BskyMessageHandler] = []
+	
+	mutating func addMessageHandlerFilters(_ filters: [any BskyMessageHandler]) {
+		mockFilters.append(contentsOf: filters)
+	}
+	
 	func processMessage(content data: Data) throws -> BskyMessage {
 		throw BskyMessageManagerError.nonValidMessage
 	}
 	
 	func processMessage(string value: String) throws -> BskyMessage {
 		throw BskyMessageManagerError.nonValidMessage
+	}
+}
+
+extension MockMessageManager: TestableMessageManager {
+	var filtersCount: Int {
+		return mockFilters.count
+	}
+}
+
+extension AllMessagesManager: TestableMessageManager {
+	var filtersCount: Int {
+		self.handlersChain.count
 	}
 }

--- a/Tests/MonarcaTests/Mocks/MockMessages.swift
+++ b/Tests/MonarcaTests/Mocks/MockMessages.swift
@@ -218,7 +218,7 @@ enum MockMessages {
 		"""
 	}
 	
-	static var commitPostWithFacet: String {
+	static var commitPostWithFacetLink: String {
 		"""
 		{
 		"did": "did:plc:4imeuitzy2wizyngczhdguzn",
@@ -286,6 +286,73 @@ enum MockMessages {
 		}
 		}
 		"""
+	}
+	
+	static var commitPostWithFacetTag: String {
+		#"""
+		  {
+			"did": "did:plc:bwyv46hd3sueap2ewknmczoe",
+			"time_us": 1751625577863550,
+			"kind": "commit",
+			"commit": {
+			  "rev": "3lt52i5ztju2s",
+			  "operation": "create",
+			  "collection": "app.bsky.feed.post",
+			  "rkey": "3lt52i5jl2s2y",
+			  "record": {
+				"$type": "app.bsky.feed.post",
+				"createdAt": "2025-07-04T10:39:35.679Z",
+				"embed": {
+				  "$type": "app.bsky.embed.video",
+				  "aspectRatio": { "height": 720, "width": 1280 },
+				  "video": {
+					"$type": "blob",
+					"ref": {
+					  "$link": "bafkreigdnbtqfjvuvigsfxemhkz22znxf45sn3fcmt3net5advmlfgxonu"
+					},
+					"mimeType": "video/mp4",
+					"size": 5661796
+				  }
+				},
+				"facets": [
+				  {
+					"features": [
+					  { "$type": "app.bsky.richtext.facet#tag", "tag": "MarioKartWorld" }
+					],
+					"index": { "byteEnd": 186, "byteStart": 171 }
+				  },
+				  {
+					"features": [
+					  { "$type": "app.bsky.richtext.facet#tag", "tag": "VTuber" }
+					],
+					"index": { "byteEnd": 194, "byteStart": 187 }
+				  },
+				  {
+					"features": [
+					  { "$type": "app.bsky.richtext.facet#tag", "tag": "TwitchClips" }
+					],
+					"index": { "byteEnd": 207, "byteStart": 195 }
+				  },
+				  {
+					"features": [
+					  { "$type": "app.bsky.richtext.facet#tag", "tag": "CozyChaos" }
+					],
+					"index": { "byteEnd": 218, "byteStart": 208 }
+				  },
+				  {
+					"features": [
+					  { "$type": "app.bsky.richtext.facet#tag", "tag": "ClutchPlay" }
+					],
+					"index": { "byteEnd": 230, "byteStart": 219 }
+				  }
+				],
+				"langs": ["en"],
+				"text": "Just pulled off the most insane ghost clutch in Mario Kart World 👻⚡\nFrom 3rd to 1st in the blink of an eye—pure chaos and perfect timing!\n🎥 Check it out: [link]\n#MarioKartWorld #VTuber #TwitchClips #CozyChaos #ClutchPlay"
+			  },
+			  "cid": "bafyreidvpuzastwn2mm76wocun3x7gs6g3nlzf6edxammrpehodaqej4im"
+			}
+		  }
+		"""#
 	}
 	
 	static var commitDeleted: String {

--- a/Tests/MonarcaTests/MonarcaTests.swift
+++ b/Tests/MonarcaTests/MonarcaTests.swift
@@ -3,34 +3,19 @@ import Testing
 
 @Suite("Client tests. Conecction and message processing.")
 struct MonarcaTests {
-	//@Test("Connect and close Jetstream connection", .tags(.client))
-	func testClientConnectionAndCloseConnection() async throws {
-		let bskyClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withMessageManager(MockMessageManager())
-			.build()
-		
-		try await bskyClient.start()
-		#expect(await bskyClient.isConnected)
-		
-		await bskyClient.stop()
-		#expect(await bskyClient.isConnected == false)
-	}
-	
 	@Test("Receive a message from the BlueSky Jetstream", .tags(.client))
 	func testClientMessageReceived() async throws {
-		let bskyClient = try await DefaultFirehoseClientBuilder()
-			.withHost(.usaEast1)
-			.withMessageManager(MockMessageManager())
-			.build()
-		
-		await bskyClient.onMessageReceived { message in
-			print("📣 \(message)")
+		let messageReceivedClosure: @Sendable (BskyMessage) -> Void = { message in
 			#expect(true)
 		}
 		
+		let bskyClient = try await DefaultFirehoseClientBuilder()
+			.withHost(.usaEast1)
+			.withMessageManager(MockMessageManager())
+			.onMessageReceived(messageReceivedClosure)
+			.build()
+		
 		try await bskyClient.start()
-		#expect(await bskyClient.isConnected)
 	}
 }
 

--- a/Tests/MonarcaTests/MonarcaTests.swift
+++ b/Tests/MonarcaTests/MonarcaTests.swift
@@ -25,7 +25,7 @@ struct MonarcaTests {
 			.build()
 		
 		await bskyClient.onMessageReceived { message in
-			print(message)
+			print("📣 \(message)")
 			#expect(true)
 		}
 		

--- a/Tests/MonarcaTests/MonarcaTests.swift
+++ b/Tests/MonarcaTests/MonarcaTests.swift
@@ -5,15 +5,14 @@ import Testing
 struct MonarcaTests {
 	@Test("Receive a message from the BlueSky Jetstream", .tags(.client))
 	func testClientMessageReceived() async throws {
-		let messageReceivedClosure: @Sendable (BskyMessage) -> Void = { message in
-			#expect(true)
-		}
-		
-		let bskyClient = try await DefaultFirehoseClientBuilder()
+		let bskyClient = try DefaultFirehoseClientBuilder()
 			.withHost(.usaEast1)
 			.withMessageManager(MockMessageManager())
-			.onMessageReceived(messageReceivedClosure)
 			.build()
+		
+		await bskyClient.onMessageReceived { message in
+			#expect(true)
+		}
 		
 		try await bskyClient.start()
 	}

--- a/Tests/MonarcaTests/MonarcaTests.swift
+++ b/Tests/MonarcaTests/MonarcaTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Suite("Client tests. Conecction and message processing.")
 struct MonarcaTests {
-	@Test("Connect and close Jetstream connection", .tags(.client))
+	//@Test("Connect and close Jetstream connection", .tags(.client))
 	func testClientConnectionAndCloseConnection() async throws {
 		let bskyClient = try await DefaultFirehoseClientBuilder()
 			.withHost(.usaEast1)
@@ -31,7 +31,6 @@ struct MonarcaTests {
 		
 		try await bskyClient.start()
 		#expect(await bskyClient.isConnected)
-		await bskyClient.receive()
 	}
 }
 

--- a/Tests/MonarcaTests/SettingsTests.swift
+++ b/Tests/MonarcaTests/SettingsTests.swift
@@ -16,42 +16,45 @@ struct SettingsTests {
 	func testEmptyDescription() async {
 		let settings = BskyFirehoseSettings()
 		
-		#expect(await settings.description.starts(with: "⚠️"))
+		let content = settings.description
+		let newLineCharactersCount = content.filter(\.isNewline).count
+		
+		#expect(newLineCharactersCount == 0)
 	}
 	
 	@Test("", .tags(.settings))
 	func testWithSingleLineDescriptionContent() async {
 		let settings: BskyFirehoseSettings = await .defaultEastCoast
 		
-		let content = await settings.description
+		let content = settings.description
 		
 		#expect(content.starts(with: "Host"))
 	}
 	
 	@Test("", .tags(.settings))
 	func testWithTwoLinesDescriptionContent() async {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
-		await settings.set(maximumMessageSize: .megabytes(value: 5))
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
+		settings.set(maximumMessageSize: .megabytes(value: 5))
 		
-		let content = await settings.description
+		let content = settings.description
 		let newLineCharactersCount = content.filter(\.isNewline).count
 		
-		#expect(newLineCharactersCount == 1)
+		#expect(newLineCharactersCount == 2)
 	}
 	
 	@Test("", .tags(.settings))
 	func testWithMultipleLinesDescriptionContent() async {
-		let settings = BskyFirehoseSettings()
-		await settings.set(host: .usaEast1)
-		await settings.set(maximumMessageSize: .megabytes(value: 5))
-		await settings.set(playback: .milliseconds(5))
-		await settings.set(collections: [ "Swift", "Vapor" ])
-		await settings.set(isHelloRequired: false)
-		await settings.set(decentralizedIdentifiers: [ "did:97531", "did:13579" ])
-		await settings.set(isCompressionEnabled: false)
+		var settings = BskyFirehoseSettings()
+		settings.set(host: .usaEast1)
+		settings.set(maximumMessageSize: .megabytes(value: 5))
+		settings.set(playback: .milliseconds(5))
+		settings.set(collections: [ "Swift", "Vapor" ])
+		settings.set(isHelloRequired: false)
+		settings.set(decentralizedIdentifiers: [ "did:97531", "did:13579" ])
+		settings.set(isCompressionEnabled: false)
 		
-		let content = await settings.description
+		let content = settings.description
 		let newLineCharactersCount = content.filter(\.isNewline).count
 		print(content)
 		#expect(newLineCharactersCount > 1)


### PR DESCRIPTION
- Migrate from the `URLSessionWebSocketTask` to the [SwiftNIO](https://github.com/apple/swift-nio) based WebSocket connection using the [WebSocketKit](https://github.com/vapor/websocket-kit) framework
- Renaming some `BskyFirehoseClientBuilder` functions to bring a *Fluid* approach to the API. Old funcions are now marked as *deprecated* and will be removed in future versions.
- Work to adopt Swift 6 Concurrency model is still in progress.
- Now you can filter `app.bsky.feed.post` messages by hashtag or by content with the new functions availables in the `BskyFirehoseClientBuilder` implementation
	- `applyContentFilter(by:)` Process only those messages that contains 1 or N of the given hashtags
	- `applyHashtagFilter(by:)` Process only those messages that contains 1 or N of the given words
- Information about **video** in a *Post* message.
- Support for the following Commit collections
	- `app.bsky.feed.threadgate`
	- `app.bsky.feed.postgate`